### PR TITLE
Fix test-all failing when re-running the same test with different nemesis (#1599)

### DIFF
--- a/yugabyte/src/yugabyte/core.clj
+++ b/yugabyte/src/yugabyte/core.clj
@@ -60,37 +60,37 @@
   (or (= (name w) "none") (= (name w) "sleep")))
 
 (defn with-client
-  [workload client]
+  [workload client-ctor]
   "Wraps a workload function to add :client entry to the result"
-  (fn [opts] (assoc (workload opts) :client client)))
+  (fn [opts] (assoc (workload opts) :client (eval client-ctor))))
 
 (def workloads-ycql
   "A map of workload names to functions that can take option maps and construct workloads."
   #:ycql{:none            noop-test
-         :counter         (with-client counter/workload (yugabyte.ycql.counter/->CQLCounterClient))
-         :set             (with-client set/workload (yugabyte.ycql.set/->CQLSetClient))
-         :set-index       (with-client set/workload (yugabyte.ycql.set/->CQLSetIndexClient))
-         :bank            (with-client bank/workload-allow-neg (yugabyte.ycql.bank/->CQLBank))
+         :counter         (with-client counter/workload '(yugabyte.ycql.counter/->CQLCounterClient))
+         :set             (with-client set/workload '(yugabyte.ycql.set/->CQLSetClient))
+         :set-index       (with-client set/workload '(yugabyte.ycql.set/->CQLSetIndexClient))
+         :bank            (with-client bank/workload-allow-neg '(yugabyte.ycql.bank/->CQLBank))
          ; Shouldn't be used until we support transactions with selects.
-         ; :bank-multitable (with-client bank/workload-allow-neg (yugabyte.ycql.bank/->CQLMultiBank))
-         :long-fork       (with-client long-fork/workload (yugabyte.ycql.long-fork/->CQLLongForkIndexClient))
-         :single-key-acid (with-client single-key-acid/workload (yugabyte.ycql.single-key-acid/->CQLSingleKey))
-         :multi-key-acid  (with-client multi-key-acid/workload (yugabyte.ycql.multi-key-acid/->CQLMultiKey))})
+         ; :bank-multitable (with-client bank/workload-allow-neg '(yugabyte.ycql.bank/->CQLMultiBank))
+         :long-fork       (with-client long-fork/workload '(yugabyte.ycql.long-fork/->CQLLongForkIndexClient))
+         :single-key-acid (with-client single-key-acid/workload '(yugabyte.ycql.single-key-acid/->CQLSingleKey))
+         :multi-key-acid  (with-client multi-key-acid/workload '(yugabyte.ycql.multi-key-acid/->CQLMultiKey))})
 
 (def workloads-ysql
   "A map of workload names to functions that can take option maps and construct workloads."
   #:ysql{:none            noop-test
          :sleep           sleep-test
-         :counter         (with-client counter/workload (yugabyte.ysql.counter/->YSQLCounterClient))
-         :set             (with-client set/workload (yugabyte.ysql.set/->YSQLSetClient))
+         :counter         (with-client counter/workload '(yugabyte.ysql.counter/->YSQLCounterClient))
+         :set             (with-client set/workload '(yugabyte.ysql.set/->YSQLSetClient))
          ; This one doesn't work because of https://github.com/YugaByte/yugabyte-db/issues/1554
-         ; :set-index       (with-client set/workload (yugabyte.ysql.set/->YSQLSetIndexClient))
+         ; :set-index       (with-client set/workload '(yugabyte.ysql.set/->YSQLSetIndexClient))
          ; We'd rather allow negatives for now because it makes reproducing error easier
-         :bank            (with-client bank/workload-allow-neg (yugabyte.ysql.bank/->YSQLBankClient true))
-         :bank-multitable (with-client bank/workload-allow-neg (yugabyte.ysql.bank/->YSQLMultiBankClient true))
-         :long-fork       (with-client long-fork/workload (yugabyte.ysql.long-fork/->YSQLLongForkClient))
-         :single-key-acid (with-client single-key-acid/workload (yugabyte.ysql.single-key-acid/->YSQLSingleKeyAcidClient))
-         :multi-key-acid  (with-client multi-key-acid/workload (yugabyte.ysql.multi-key-acid/->YSQLMultiKeyAcidClient))})
+         :bank            (with-client bank/workload-allow-neg '(yugabyte.ysql.bank/->YSQLBankClient true))
+         :bank-multitable (with-client bank/workload-allow-neg '(yugabyte.ysql.bank/->YSQLMultiBankClient true))
+         :long-fork       (with-client long-fork/workload '(yugabyte.ysql.long-fork/->YSQLLongForkClient))
+         :single-key-acid (with-client single-key-acid/workload '(yugabyte.ysql.single-key-acid/->YSQLSingleKeyAcidClient))
+         :multi-key-acid  (with-client multi-key-acid/workload '(yugabyte.ysql.multi-key-acid/->YSQLMultiKeyAcidClient))})
 
 (def workloads
   (merge workloads-ycql workloads-ysql))

--- a/yugabyte/src/yugabyte/core.clj
+++ b/yugabyte/src/yugabyte/core.clj
@@ -106,7 +106,8 @@
   "Only workloads and options that we think should pass. Also used for
   test-all."
   (-> workload-options
-      (dissoc :ycql/bank-multitable)))
+      (dissoc :ycql/bank-multitable
+              :ysql/sleep)))
 
 (def nemesis-specs
   "These are the types of failures that the nemesis can perform."

--- a/yugabyte/src/yugabyte/core.clj
+++ b/yugabyte/src/yugabyte/core.clj
@@ -59,38 +59,39 @@
   [w]
   (or (= (name w) "none") (= (name w) "sleep")))
 
-(defn with-client
+(defmacro with-client
   [workload client-ctor]
-  "Wraps a workload function to add :client entry to the result"
-  (fn [opts] (assoc (workload opts) :client (eval client-ctor))))
+  "Wraps a workload function to add :client entry to the result.
+  Made as macro to re-evaluate client on every invocation."
+  `(fn [~'opts] (assoc (~workload ~'opts) :client ~client-ctor)))
 
 (def workloads-ycql
   "A map of workload names to functions that can take option maps and construct workloads."
   #:ycql{:none            noop-test
-         :counter         (with-client counter/workload '(yugabyte.ycql.counter/->CQLCounterClient))
-         :set             (with-client set/workload '(yugabyte.ycql.set/->CQLSetClient))
-         :set-index       (with-client set/workload '(yugabyte.ycql.set/->CQLSetIndexClient))
-         :bank            (with-client bank/workload-allow-neg '(yugabyte.ycql.bank/->CQLBank))
+         :counter         (with-client counter/workload (yugabyte.ycql.counter/->CQLCounterClient))
+         :set             (with-client set/workload (yugabyte.ycql.set/->CQLSetClient))
+         :set-index       (with-client set/workload (yugabyte.ycql.set/->CQLSetIndexClient))
+         :bank            (with-client bank/workload-allow-neg (yugabyte.ycql.bank/->CQLBank))
          ; Shouldn't be used until we support transactions with selects.
-         ; :bank-multitable (with-client bank/workload-allow-neg '(yugabyte.ycql.bank/->CQLMultiBank))
-         :long-fork       (with-client long-fork/workload '(yugabyte.ycql.long-fork/->CQLLongForkIndexClient))
-         :single-key-acid (with-client single-key-acid/workload '(yugabyte.ycql.single-key-acid/->CQLSingleKey))
-         :multi-key-acid  (with-client multi-key-acid/workload '(yugabyte.ycql.multi-key-acid/->CQLMultiKey))})
+         ; :bank-multitable (with-client bank/workload-allow-neg (yugabyte.ycql.bank/->CQLMultiBank))
+         :long-fork       (with-client long-fork/workload (yugabyte.ycql.long-fork/->CQLLongForkIndexClient))
+         :single-key-acid (with-client single-key-acid/workload (yugabyte.ycql.single-key-acid/->CQLSingleKey))
+         :multi-key-acid  (with-client multi-key-acid/workload (yugabyte.ycql.multi-key-acid/->CQLMultiKey))})
 
 (def workloads-ysql
   "A map of workload names to functions that can take option maps and construct workloads."
   #:ysql{:none            noop-test
          :sleep           sleep-test
-         :counter         (with-client counter/workload '(yugabyte.ysql.counter/->YSQLCounterClient))
-         :set             (with-client set/workload '(yugabyte.ysql.set/->YSQLSetClient))
+         :counter         (with-client counter/workload (yugabyte.ysql.counter/->YSQLCounterClient))
+         :set             (with-client set/workload (yugabyte.ysql.set/->YSQLSetClient))
          ; This one doesn't work because of https://github.com/YugaByte/yugabyte-db/issues/1554
-         ; :set-index       (with-client set/workload '(yugabyte.ysql.set/->YSQLSetIndexClient))
+         ; :set-index       (with-client set/workload (yugabyte.ysql.set/->YSQLSetIndexClient))
          ; We'd rather allow negatives for now because it makes reproducing error easier
-         :bank            (with-client bank/workload-allow-neg '(yugabyte.ysql.bank/->YSQLBankClient true))
-         :bank-multitable (with-client bank/workload-allow-neg '(yugabyte.ysql.bank/->YSQLMultiBankClient true))
-         :long-fork       (with-client long-fork/workload '(yugabyte.ysql.long-fork/->YSQLLongForkClient))
-         :single-key-acid (with-client single-key-acid/workload '(yugabyte.ysql.single-key-acid/->YSQLSingleKeyAcidClient))
-         :multi-key-acid  (with-client multi-key-acid/workload '(yugabyte.ysql.multi-key-acid/->YSQLMultiKeyAcidClient))})
+         :bank            (with-client bank/workload-allow-neg (yugabyte.ysql.bank/->YSQLBankClient true))
+         :bank-multitable (with-client bank/workload-allow-neg (yugabyte.ysql.bank/->YSQLMultiBankClient true))
+         :long-fork       (with-client long-fork/workload (yugabyte.ysql.long-fork/->YSQLLongForkClient))
+         :single-key-acid (with-client single-key-acid/workload (yugabyte.ysql.single-key-acid/->YSQLSingleKeyAcidClient))
+         :multi-key-acid  (with-client multi-key-acid/workload (yugabyte.ysql.multi-key-acid/->YSQLMultiKeyAcidClient))})
 
 (def workloads
   (merge workloads-ycql workloads-ysql))


### PR DESCRIPTION
Fixes https://github.com/YugaByte/yugabyte-db/issues/1599

(Note that running `test-all` still fails, this time with OOM, tracked separately under https://github.com/YugaByte/yugabyte-db/issues/1616)