### PR TITLE
Wrapped transactional tests read in SNAPSHOT txn (YugaByte/yugabyte-db#1553)

### DIFF
--- a/yugabyte/src/yugabyte/ysql/bank.clj
+++ b/yugabyte/src/yugabyte/ysql/bank.clj
@@ -12,6 +12,14 @@
 ; Single-table bank test
 ;
 
+(defn- read-accounts-map
+  "Read {id balance} accounts map from a unified bank table"
+  [op c]
+  (->> (str "SELECT id, balance FROM " table-name)
+       (c/query c)
+       (map (juxt :id :balance))
+       (into (sorted-map))))
+
 (defrecord YSQLBankYbClient [allow-negatives?]
   c/YSQLYbClient
 
@@ -30,16 +38,14 @@
   (invoke-op! [this test op c conn-wrapper]
     (case (:f op)
       :read
-      (->> (str "SELECT id, balance FROM " table-name)
-           (c/query c)
-           (map (juxt :id :balance))
-           (into (sorted-map))
-           (assoc op :type :ok, :value))
+      (c/with-snapshot=txn
+        c
+        (assoc op :type :ok, :value (read-accounts-map op c)))
 
       :transfer
-      (let [{:keys [from to amount]} (:value op)]
-        (c/with-txn
-          c
+      (c/with-txn
+        c
+        (let [{:keys [from to amount]} (:value op)]
           (let [b-from-before (c/select-single-value c table-name :balance (str "id = " from))
                 b-to-before   (c/select-single-value c table-name :balance (str "id = " to))
                 b-from-after  (- b-from-before amount)

--- a/yugabyte/src/yugabyte/ysql/client.clj
+++ b/yugabyte/src/yugabyte/ysql/client.clj
@@ -245,6 +245,12 @@
   `(j/with-db-transaction [~c ~c {:isolation isolation-level}]
                           ~@body))
 
+(defmacro with-snapshot=txn
+  "Wrap evaluation within an SQL transaction using the SNAPSHOT isolation level.
+  Should be used for pure read transactions."
+  [c & body]
+  `(j/with-db-transaction [~c ~c {:isolation :repeatable-read}] ; aka SNAPSHOT in YB
+                          ~@body))
 
 (defmacro with-errors
   "Takes an operation and a body. Evaluates body, catches exceptions, and maps


### PR DESCRIPTION
YugaByte/yugabyte-db#1553 has been resolved by commit https://github.com/YugaByte/yugabyte-db/commit/c6094c601f549cda911ed62594673f7e89c2be54#diff-d3c201bef954460f73e9f350d6148ac4L91, but for the tests involving explicit transactions, the (pure) read operations should be explicitly wrapped in snapshot txn