### PR TITLE
Fix outdated versions (YugaByte/yugabyte-db#938)

### DIFF
--- a/yugabyte/src/yugabyte/auto.clj
+++ b/yugabyte/src/yugabyte/auto.clj
@@ -243,7 +243,7 @@
 (defn get-download-url
   "Returns URL to tarball for specific released version"
   [version]
-  (str "https://downloads.yugabyte.com/yugabyte-ce-" version "-linux.tar.gz"))
+  (str "https://downloads.yugabyte.com/yugabyte-" version "-linux.tar.gz"))
 
 (defn log-files-without-symlinks
   "Takes a directory, and returns a list of logfiles in that direcory, skipping

--- a/yugabyte/src/yugabyte/core.clj
+++ b/yugabyte/src/yugabyte/core.clj
@@ -194,7 +194,9 @@
   name, OS, DB."
   [opts]
   (assoc opts
-    :name (str "yb " (:version opts)
+    :name (str "yb " (-> (or (:url opts) (:version opts))
+                         (str/split #"/")
+                         (last))
                " " (name (:workload opts))
                (when-not (= [:interval] (keys (:nemesis opts)))
                  (str " nemesis " (->> (dissoc (:nemesis opts) :interval)

--- a/yugabyte/src/yugabyte/runner.clj
+++ b/yugabyte/src/yugabyte/runner.clj
@@ -94,7 +94,7 @@
     :default false]
 
    [nil "--version VERSION" "What version of Yugabyte to install"
-    :default "1.1.10.0"]
+    :default "1.3.1.0"]
 
    [nil "--url URL" "URL to Yugabyte tarball to install, has precedence over --version"
     :default nil]


### PR DESCRIPTION
(Done as a part of YugaByte/yugabyte-db#938)
* Updated default version to latest
* Fixed download URL still pointing to CE release (now invalid)
* Fixed default version being used as a version for YB downloaded via explicit URL