### PR TITLE
Stop postgres process as a part of DB teardown (YugaByte/yugabyte-db#1986)

### DIFF
--- a/yugabyte/src/yugabyte/auto.clj
+++ b/yugabyte/src/yugabyte/auto.clj
@@ -266,6 +266,8 @@
 (def ce-tserver-logfile (str ce-tserver-log-dir "/stdout"))
 (def ce-tserver-pidfile (str dir "/tserver.pid"))
 
+(def postgres-bin       (str dir "/postgres/bin/postgres"))
+
 (defn ce-shared-opts
   "Shared options for both master and tserver"
   [node]
@@ -385,7 +387,8 @@
     (c/su (cu/stop-daemon! ce-master-bin ce-master-pidfile)))
 
   (stop-tserver! [db]
-    (c/su (cu/stop-daemon! ce-tserver-bin ce-tserver-pidfile)))
+    (c/su (cu/stop-daemon! ce-tserver-bin ce-tserver-pidfile))
+    (c/su (cu/grepkill! postgres-bin)))
 
   (wipe! [db]
     (c/su (c/exec :rm :-rf ce-data-dir)))


### PR DESCRIPTION
We're doing `grepkill` (essentially `ps -aux | grep <pattern> | xargs --no-run-if-empty kill -9`) instead of cleaner `stop-daemon!` because for some reason `postmaster.pid` contains a lot of garbage:
```
root@n1:~# cat /home/yugabyte/master.pid
20656
```
```
root@n1:~# cat /home/yugabyte/data/pg_data/postmaster.pid
20741
/home/yugabyte/data/pg_data
1565395171
5433

192.168.122.11
  5433001  69009408
ready
```

Tested this on my Jepsen setup, test seem to work fine both whether YB is running or not