### PR TITLE
Adapt Jepsen to the new state of YB

### DIFF
--- a/yugabyte/src/yugabyte/ysql/client.clj
+++ b/yugabyte/src/yugabyte/ysql/client.clj
@@ -147,6 +147,7 @@
       {:name  node
        :open  (partial open-conn node)
        :close close-conn
+       ; Do not log intermediate reconnection errors (if the reconnect fails, we'll still get it)
        :log?  false})))
 
 (defprotocol YSQLYbClient

--- a/yugabyte/src/yugabyte/ysql/client.clj
+++ b/yugabyte/src/yugabyte/ysql/client.clj
@@ -147,7 +147,7 @@
       {:name  node
        :open  (partial open-conn node)
        :close close-conn
-       :log?  true})))
+       :log?  false})))
 
 (defprotocol YSQLYbClient
   "Used by defclient macro in conjunction with jepsen.client/Client specifying actual logic"


### PR DESCRIPTION
* Teach Jepsen about `Could not locate the leader master` error message.
* Suppress some of the `InterruptedException`s to reduce clutter when Jepsen errors out.
* Disable internal logging of Jepsen's YSQL connection wrapper as not useful and distracting.