### PR TITLE
yugabyte: run-jepsen log file name fix

### DIFF
--- a/yugabyte/README.md
+++ b/yugabyte/README.md
@@ -151,7 +151,7 @@ To run test with specific nemesis, for example `start-stop-master`:
 lein run test --nodes-file ~/code/jepsen/nodes --nemesis start-stop-master
 ```
 
-To run all tests one by one under each nemesis in infinite loop:
+Wrapper to manage log files seperately and summarize tests, for use in automated jenkins testing:
 ```bash
 ./run-jepsen.py
 ```

--- a/yugabyte/run-jepsen.py
+++ b/yugabyte/run-jepsen.py
@@ -360,7 +360,7 @@ def main():
             logging.info("Finished running %d tests.", num_tests_run)
             logging.info("    %d OK, %d Problems (%d Timed-Out)",
                 num_everything_looks_good, num_not_everything_looks_good, num_timed_out_tests)
-            logging.info("    %d exitted 0, %d exitted non-zero.", num_zero_exit_code,
+            logging.info("    %d exited success, %d exited failure.", num_zero_exit_code,
                 num_non_zero_exit_code)
             logging.info("Elapsed time: %.1f sec, Test time: %.1f sec, Avg test time: %.1f sec", 
                 total_elapsed_time_sec, total_test_time_sec,
@@ -369,9 +369,9 @@ def main():
                 logging.info("Tests where something does not look good:\n    %s",
                              "\n    ".join(not_good_tests))
         if num_not_everything_looks_good + num_non_zero_exit_code > 0:
-            exit 1
+            exit(1)
         else:
-            exit 0
+            exit(0)
 
 
 if __name__ == '__main__':

--- a/yugabyte/run-jepsen.py
+++ b/yugabyte/run-jepsen.py
@@ -359,7 +359,7 @@ def main():
         if not_good_tests:
             logging.info("Tests where something does not look good:\n    %s",
                          "\n    ".join(not_good_tests))
-    if num_not_everything_looks_good + num_non_zero_exit_code > 0:
+    if not_good_tests:
         exit(1)
     else:
         exit(0)

--- a/yugabyte/run-jepsen.py
+++ b/yugabyte/run-jepsen.py
@@ -309,7 +309,7 @@ def main():
                     ]),
                     timeout=TEST_AND_ANALYSIS_TIMEOUT_SEC,
                     exit_on_error=False,
-                    log_name_prefix="{}_nemesis_{}".format(test, nemesis),
+                    log_name_prefix="{}_nemesis_{}".format(test.replace('/','-'), nemesis),
                     keep_output_log_file=False,
                     num_lines_to_show=50
                 )

--- a/yugabyte/run-jepsen.py
+++ b/yugabyte/run-jepsen.py
@@ -231,8 +231,16 @@ def parse_args():
         help='Enable clock skew nemesis. This will not work on LXC.')
     parser.add_argument(
         '--concurrency',
-        default='4n',
+        default='5n',
         help='Concurrency to specify, e.g. 2n, 4n, or 5n, where n means the number of nodes.')
+    parser.add_argument(
+        '--workloads',
+        default=','.join(TESTS),
+        help='Comma-seperated list of workloads. Default: ' + ','.join(TESTS))
+    parser.add_argument(
+        '--nemeses',
+        default=','.join(NEMESES),
+        help='Comma-seperated list of nemeses. Default: ' + ','.join(NEMESES))
     return parser.parse_args()
 
 
@@ -248,7 +256,7 @@ def main():
     run_cmd(SORT_RESULTS_SH)
 
     start_time = time.time()
-    nemeses = NEMESES
+    nemeses = args.nemeses.split(',')
     if args.enable_clock_skew:
         nemeses += ['clock-skew']
 
@@ -275,7 +283,7 @@ def main():
         for nemesis in nemeses:
             if is_done:
                 break
-            for test in TESTS:
+            for test in args.workloads.split(','):
                 total_elapsed_time_sec = time.time() - start_time
                 if args.max_time_sec is not None and total_elapsed_time_sec > args.max_time_sec:
                     logging.info(
@@ -309,7 +317,7 @@ def main():
                     timeout=TEST_AND_ANALYSIS_TIMEOUT_SEC,
                     exit_on_error=False,
                     log_name_prefix="{}_nemesis_{}".format(test.replace('/','-'), nemesis),
-                    num_lines_to_show=50
+                    num_lines_to_show=30
                 )
 
                 test_elapsed_time_sec = time.time() - test_start_time_sec
@@ -356,7 +364,7 @@ def main():
                 logging.info("    %d tests timed out.", num_timed_out_tests)
                 logging.info("    %d tests returned zero exit code (OK).", num_zero_exit_code)
                 logging.info(
-                    "    %d tests returned non-zero exit code (not OK -- may includes timeouts).".
+                    "    %d tests returned non-zero exit code (not OK -- may includes timeouts).",
                     num_non_zero_exit_code)
                 logging.info("Total elapsed time: %.1f sec", total_elapsed_time_sec)
                 logging.info("Total test time: %.1f sec", total_test_time_sec)

--- a/yugabyte/run-jepsen.py
+++ b/yugabyte/run-jepsen.py
@@ -74,7 +74,6 @@ NEMESES = [
     "pause-tserver",
     "pause-master",
     "partition",
-    "kill,pause,partition",
     # "clock-skew",
 ]
 
@@ -236,8 +235,8 @@ def parse_args():
         help='Comma-seperated list of workloads. Default: ' + ','.join(TESTS))
     parser.add_argument(
         '--nemeses',
-        default=' '.join(NEMESES),
-        help='Comma-seperated list of nemeses. Default: ' + ' '.join(NEMESES))
+        default=','.join(NEMESES),
+        help='Comma-seperated list of nemeses. Default: ' + ','.join(NEMESES))
     return parser.parse_args()
 
 

--- a/yugabyte/sort-results.sh
+++ b/yugabyte/sort-results.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-readonly SAVED_DIR=$(pwd)
+readonly SAVED_DIR="$(pwd)"
 
 readonly SCRIPT_DIR="${0%/*}"
 readonly STORE_DIR="$SCRIPT_DIR/store"
@@ -16,8 +16,8 @@ cd "${0%/*}"
 
 find $STORE_DIR -name "jepsen.log" -printf "%T+\t%p\n" | sort | cut -f2 |
   while IFS= read -r log_path; do
-    rel_log_path=${log_path#$STORE_DIR/}
-    rel_dir_path=${rel_log_path%/jepsen.log}
+    rel_log_path="${log_path#$STORE_DIR/}"
+    rel_dir_path="${rel_log_path%/jepsen.log}"
     if grep -q ':valid? false' "$log_path"; then
       category="invalid"
     elif grep -q ':valid? :unknown' "$log_path"; then


### PR DESCRIPTION
New test names have slashes, but log file name cannot contain slash.