### PR TITLE
Quality of life improvements

### DIFF
--- a/yugabyte/src/yugabyte/runner.clj
+++ b/yugabyte/src/yugabyte/runner.clj
@@ -77,7 +77,7 @@
     :validate [(complement neg?) "should be a non-negative number"]]
 
    [nil "--nemesis-long-recovery" "Every so often, have a long period of no faults, to see whether the cluster recovers."
-    :default false
+    :default true
     :assoc-fn (fn [m k v] (update m :nemesis assoc :long-recovery v))]
 
    [nil "--nemesis-schedule SCHEDULE" "Whether to have randomized delays between nemesis actions, or fixed ones."


### PR DESCRIPTION
1) Naming schema changed from
`yb <ver> <workload> nemesis <nemesis>`
to
`yb_<ver>_<api>_<workload>_nemesis_<nemesis>`
This way, API (YCQL/YSQL) is immediately visible without having to open the log, and whitespaces (which aren't great in Unix file names) are no longer used.

2) `--nemesis-long-recovery` (letting cluster some time free from nemeses to recover) now defaults to `true`. This should resolve https://github.com/yugabyte/yugabyte-db/issues/8636