### PR TITLE
updated jepsen to 0.2.4

### DIFF
--- a/yugabyte/project.clj
+++ b/yugabyte/project.clj
@@ -5,7 +5,7 @@
             :url  "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.10.0"]
                  [clj-http "3.8.0" :exclusions [commons-logging]]
-                 [jepsen "0.1.19"]
+                 [jepsen "0.2.4"]
                  [com.yugabyte/cassaforte "3.0.0-alpha2-yb-1"]
                  [org.clojure/java.jdbc "0.7.9"]
                  [org.postgresql/postgresql "42.2.5"]

--- a/yugabyte/run-jepsen.py
+++ b/yugabyte/run-jepsen.py
@@ -92,7 +92,7 @@ def cleanup():
             time.sleep(1)
         try:
             p.kill()
-        except OSError, e:
+        except OSError as e:
             if e.errno != errno.ESRCH:
                 raise e
 
@@ -109,7 +109,7 @@ def truncate_line(line, max_chars=500):
 def get_last_lines(file_path, n_lines):
     total_num_lines = int(subprocess.check_output(['wc', '-l', file_path]).strip().split()[0])
     return (
-        subprocess.check_output(['tail', '-n', str(n_lines), file_path]).split("\n"),
+        subprocess.check_output(['tail', '-n', str(n_lines), file_path]).decode().split("\n"),
         total_num_lines
     )
 
@@ -198,7 +198,7 @@ def run_cmd(cmd,
             if not keep_output_log_file:
                 try:
                     os.remove(stdout_path)
-                except IOError, ex:
+                except IOError as ex:
                     logging.error("Error deleting output log %s, ignoring: %s", stdout_path, ex)
         if stderr_file is not None:
             stderr_file.close()
@@ -206,7 +206,7 @@ def run_cmd(cmd,
             if not keep_output_log_file:
                 try:
                     os.remove(stderr_path)
-                except IOError, ex:
+                except IOError as ex:
                     logging.error("Error deleting stderr log %s, ignoring: %s", stderr_path, ex)
 
 

--- a/yugabyte/src/yugabyte/core.clj
+++ b/yugabyte/src/yugabyte/core.clj
@@ -218,6 +218,7 @@
                                          (map name)
                                          sort
                                          (str/join ",")))))
+      :pure-generators true
       :os (case (:os opts)
             :centos centos/os
             :debian debian/os)
@@ -283,6 +284,7 @@
            {:client    (:client workload)
             :nemesis   (:nemesis nemesis)
             :generator gen
+            :pure-generators true
             :checker   checker})))
 
 (defn yb-test

--- a/yugabyte/src/yugabyte/counter.clj
+++ b/yugabyte/src/yugabyte/counter.clj
@@ -6,9 +6,9 @@
             [yugabyte.generator :as ygen]))
 
 
-(def add {:type :invoke :f :add :value 1})
-(def sub {:type :invoke :f :add :value -1})
-(def r   {:type :invoke :f :read})
+(defn add []  {:type :invoke :f :add :value 1})
+(defn sub []  {:type :invoke :f :add :value -1})
+(defn r   []  {:type :invoke :f :read})
 
 (defn workload
   [opts]

--- a/yugabyte/src/yugabyte/nemesis.clj
+++ b/yugabyte/src/yugabyte/nemesis.clj
@@ -136,7 +136,7 @@
 (defn flip-flop
   "Switches between ops from two generators: a, b, a, b, ..."
   [a b]
-  (gen/seq (cycle [a b])))
+  (map gen/once (cycle [a b])))
 
 (defn opt-mix
   "Given a nemesis map n, and a map of options to generators to use if that
@@ -187,8 +187,8 @@
          ; Introduce either random or fixed delays between ops
          ((case (:schedule n)
             (nil :random)    gen/stagger
-            :fixed           gen/delay-til)
-          (:interval n)))))
+            :fixed           gen/delay) ; todo think about missing delay-til
+           (:interval n)))))
 
 (defn final-generator
   "Takes a nemesis options map `n`, and constructs a generator to stop all
@@ -205,7 +205,7 @@
          (some n [:partition-one :partition-half :partition-ring])
          (conj :stop-partition))
        (map op)
-       gen/seq))
+       (map gen/once)))
 
 (defn full-generator
   "Takes a nemesis options map `n`. If `n` has a :no-recovery option, just emits faults from

--- a/yugabyte/src/yugabyte/set.clj
+++ b/yugabyte/src/yugabyte/set.clj
@@ -10,7 +10,7 @@
   []
   (->> (range)
        (map (fn [x] {:type :invoke, :f :add, :value x}))
-       gen/seq))
+       (map gen/once)))
 
 (defn reads
   []
@@ -19,7 +19,7 @@
 (defn workload
   [opts]
   {:generator (->> (gen/reserve (/ (:concurrency opts) 2) (adds)
-                                (reads))
+                                reads)
                    (gen/stagger 1/10)
                    (ygen/with-op-index))
    :checker   (checker/set-full)})


### PR DESCRIPTION
t also require to update Debian 8 up to Debian 9+ in our CI runs.

Used this guide to upgrade generators behaviour http://jepsen-io.github.io/jepsen/jepsen.generator.html

### 1. `gen/seq` changes:
_**Jepsen doc:**_
gen/seq and gen/seq-all are unnecessary; any Clojure sequence is already a pure generator. gen/seq didn’t just turn sequences into generators; it also ensured that only one operation was consumed from each. This is now explicit: use (map gen.pure/once coll) instead of (gen/seq coll), andcollinstead of(gen/seq-all coll). Where the sequence is of one-shot generators already, there's no need to wrap elements with gen/once: instead of(gen/seq [{:f :read} {:f :write}])`), you can write [{:f :read} {:f :write}] directly.
_**Our case:**_
Replaced according to documentation

### 2. removed `delay-til` usage
_**Jepsen doc:**_
delay-til is gone. It should come back; I just haven’t written it yet. Defining what exactly delay-til means is… surprisingly tricky.
_**Our case:**_
According to our usage it was kind of delay operation, so I just replace it with delay call. Should affect only composite nemesis scenarios and test runs looks good, but there may be some side-effects so I left todo there.

### 3. Usage of `:pure-generators true`
According to 0.2.0 release notes https://github.com/jepsen-io/jepsen/releases/tag/0.2.0:
Once you've confirmed that your generators are good to go, add a :pure-generators true flag to your test map. As a safety measure, Jepsen will automatically prompt you to review your generator code and refuse to run without this flag.