### PR TITLE
Append consistency model fix

### DIFF
--- a/yugabyte/src/yugabyte/append.clj
+++ b/yugabyte/src/yugabyte/append.clj
@@ -9,9 +9,9 @@
 
 (defn workload
   [opts]
-  (-> (append/test {:key-count          16
+  (-> (append/test {:key-count          32
                     :max-txn-length     4
-                    :max-writes-per-key 512
+                    :max-writes-per-key 1024
                     :anomalies          [:G1 :G2]
                     :consistency-models [:serializable]
                     :additional-graphs  [elle/realtime-graph]})))

--- a/yugabyte/src/yugabyte/append.clj
+++ b/yugabyte/src/yugabyte/append.clj
@@ -14,6 +14,7 @@
   (-> (append/test {:key-count          32
                     :max-txn-length     4
                     :max-writes-per-key 1024
-                    :anomalies         [:G1 :G2]
-                    :additional-graphs [elle/realtime-graph]})))
+                    :anomalies          [:G1 :G2]
+                    :consistency-models [:serializable]
+                    :additional-graphs  [elle/realtime-graph]})))
 ;     (update :generator (partial gen/stagger 1/5)))

--- a/yugabyte/src/yugabyte/append.clj
+++ b/yugabyte/src/yugabyte/append.clj
@@ -5,15 +5,13 @@
   value of the given list is). We detect cycles in these transactions using
   Jepsen's cycle-detection system."
   (:require [elle.core :as elle]
-            [jepsen.generator :as gen]
-            [jepsen.tests.cycle :as cycle]
             [jepsen.tests.cycle.append :as append]))
 
 (defn workload
   [opts]
-  (-> (append/test {:key-count          32
+  (-> (append/test {:key-count          16
                     :max-txn-length     4
-                    :max-writes-per-key 1024
+                    :max-writes-per-key 512
                     :anomalies          [:G1 :G2]
                     :consistency-models [:serializable]
                     :additional-graphs  [elle/realtime-graph]})))

--- a/yugabyte/src/yugabyte/ysql/append.clj
+++ b/yugabyte/src/yugabyte/ysql/append.clj
@@ -7,12 +7,6 @@
   (:require [clojure.string :as str]
             [clojure.java.jdbc :as j]
             [clojure.tools.logging :refer [info]]
-            [jepsen [client :as client]
-                    [checker :as checker]
-                    [generator :as gen]
-                    [util :as util]]
-            [jepsen.tests.cycle :as cycle]
-            [jepsen.tests.cycle.append :as append]
             [yugabyte.ysql.client :as c]))
 
 (defn table-count


### PR DESCRIPTION
Relaxed consistency checked option. We do not support strict-serialisable model.

This is seems to be the only change happened in Elle code. Not sure how it can be connected with our current failures. Anyway we need to change checker consistency check.
https://github.com/jepsen-io/elle/commit/199230b1f78e90e819f3d011c6c83401be65244f#diff-d3ad084bd2d305780b013b2c7b6be61585e949d84fcda5be22b4feafa37bc777