### PR TITLE
Version dependent tests in Jepsen

### DIFF
--- a/yugabyte/run-jepsen.py
+++ b/yugabyte/run-jepsen.py
@@ -330,17 +330,17 @@ def main():
     else:
         iteration_cnt = 1
 
-    workloads_to_skip = [workload for workload in args.workloads.split(',')
-                         if is_version_at_least(version,
-                                                get_workload_version(workload))]
+    all_workloads = args.workloads.split(',')
     workloads_to_evaluate = [workload for workload in args.workloads.split(',')
-                             if not is_version_at_least(version,
-                                                        get_workload_version(workload))]
+                             if is_version_at_least(version,
+                                                    get_workload_version(workload))]
+    workloads_to_skip = set(all_workloads) - set(workloads_to_evaluate)
 
     if not workloads_to_evaluate:
-        logging.error(f"No workloads for evaluate have been found because of version incompatibility\n"
-                      f"Should be skipped: {workloads_to_skip}\n"
-                      f"Workloads to evaluate: {workloads_to_evaluate}")
+        logging.error(
+            f"No workloads for evaluate have been found because of version incompatibility\n"
+            f"Should be skipped: {workloads_to_skip}\n"
+            f"Workloads to evaluate: {workloads_to_evaluate}")
         exit(1)
 
     for test in workloads_to_evaluate:

--- a/yugabyte/run-jepsen.py
+++ b/yugabyte/run-jepsen.py
@@ -101,11 +101,12 @@ SORT_RESULTS_SH = os.path.join(SCRIPT_DIR, "sort-results.sh")
 
 child_processes = []
 
+
 def get_workload_version(workload):
     for el in TEST_PER_VERSION:
         for tests in el["tests"]:
             if workload in tests:
-                return el["version"]
+                return el["start_version"]
     assert False, f"Unanable to find workload in tests: {TESTS}"
 
 
@@ -337,7 +338,7 @@ def main():
                     "stopping", total_elapsed_time_sec, args.max_time_sec)
                 break
 
-            
+
             if compare_versions_less_than(version, get_workload_version(test)):
                 logging.info(
                     f"Skipped workload {test} because it requires version {version}")

--- a/yugabyte/run-jepsen.py
+++ b/yugabyte/run-jepsen.py
@@ -77,7 +77,7 @@ TEST_PER_VERSION = [
         ]
     },
     {
-        "start_version": "2.13.1.0",
+        "start_version": "2.13.1.0-b0",
         "tests": [
             "ysql/append-rc"
         ]
@@ -117,7 +117,7 @@ def compare_versions_less_than(v1, v2):
         if i == j:
             continue
         return i < j
-    assert False, f"Can't compare versions {v1} and {v2}"
+    return False
 
 
 def cleanup():

--- a/yugabyte/run-jepsen.py
+++ b/yugabyte/run-jepsen.py
@@ -338,7 +338,7 @@ def main():
                                                                get_workload_version(workload))]
 
     if not workloads_to_evaluate:
-        logging.error(f"No workloads for evaluate have been found\n"
+        logging.error(f"No workloads for evaluate have been found because of version incompatibility\n"
                       f"Should be skipped: {workloads_to_skip}\n"
                       f"Workloads to evaluate: {workloads_to_evaluate}")
         exit(1)

--- a/yugabyte/run-jepsen.py
+++ b/yugabyte/run-jepsen.py
@@ -52,8 +52,7 @@ DEFAULT_TARBALL_URL = "https://downloads.yugabyte.com/yugabyte-1.3.1.0-linux.tar
 
 TEST_PER_VERSION = [
     {
-        "start_version": "2.4.0.0",
-        "tests": [
+        "2.4.0.0": [
             "ycql/counter",
             "ycql/set",
             "ycql/set-index",
@@ -77,8 +76,7 @@ TEST_PER_VERSION = [
         ]
     },
     {
-        "start_version": "2.13.1.0",
-        "tests": [
+        "2.13.1.0": [
             "ysql/append-rc"
         ]
     }
@@ -103,7 +101,7 @@ child_processes = []
 
 def get_workload_version(workload):
     for el in TEST_PER_VERSION:
-        for version, tests in el:
+        for version, tests in el.items():
             if workload in tests:
                 return version
     assert False, f"Unanable to find workload in tests: {TESTS}"

--- a/yugabyte/run-jepsen.py
+++ b/yugabyte/run-jepsen.py
@@ -110,13 +110,13 @@ def get_workload_version(workload):
     assert False, f"Unanable to find workload in tests: {TESTS}"
 
 
-def is_version_at_least(v_actual, v_least):
-    v_actual_split = re.split('\.|-b', v_actual)
+def is_version_at_least(v_least, v_actual):
     v_least_split = re.split('\.|-b', v_least)
-    for i, j in zip_longest(map(int, v_actual_split), map(int, v_least_split), fillvalue=0):
+    v_actual_split = re.split('\.|-b', v_actual)
+    for i, j in zip_longest(map(int, v_least_split), map(int, v_actual_split), fillvalue=0):
         if i == j:
             continue
-        return i > j
+        return i < j
     return False
 
 
@@ -332,8 +332,8 @@ def main():
 
     all_workloads = args.workloads.split(',')
     workloads_to_evaluate = [workload for workload in all_workloads
-                             if is_version_at_least(version,
-                                                    get_workload_version(workload))]
+                             if not is_version_at_least(version,
+                                                        get_workload_version(workload))]
     workloads_to_skip = set(all_workloads) - set(workloads_to_evaluate)
 
     if not workloads_to_evaluate:

--- a/yugabyte/run-jepsen.py
+++ b/yugabyte/run-jepsen.py
@@ -68,7 +68,7 @@ TESTS = [
    "ysql/multi-key-acid",
    "ysql/append",
    "ysql/append-si",
-   "ysql/append-rc",
+   # "ysql/append-rc",
    "ysql/default-value",
 ]
 NEMESES = [

--- a/yugabyte/run-jepsen.py
+++ b/yugabyte/run-jepsen.py
@@ -116,7 +116,7 @@ def compare_versions_less_than(v1, v2):
     for i, j in zip_longest(map(int, v1_split), map(int, v2_split), fillvalue=0):
         if i == j:
             continue
-        return i > j
+        return i < j
     assert False, f"Can't compare versions {v1} and {v2}"
 
 def cleanup():
@@ -338,10 +338,9 @@ def main():
                     "stopping", total_elapsed_time_sec, args.max_time_sec)
                 break
 
-
             if compare_versions_less_than(version, get_workload_version(test)):
                 logging.info(
-                    f"Skipped workload {test} because it requires version {version}")
+                    f"Skipped workload {test} because it requires version {get_workload_version(test)}")
                 break
 
             test_index += 1

--- a/yugabyte/run-jepsen.py
+++ b/yugabyte/run-jepsen.py
@@ -337,7 +337,7 @@ def main():
                              if not compare_versions_less_than(version,
                                                                get_workload_version(workload))]
 
-    if len(workloads_to_evaluate) == 0:
+    if not workloads_to_evaluate:
         logging.error(f"No workloads for evaluate have been found\n"
                       f"Should be skipped: {workloads_to_skip}\n"
                       f"Workloads to evaluate: {workloads_to_evaluate}")

--- a/yugabyte/run-jepsen.py
+++ b/yugabyte/run-jepsen.py
@@ -119,6 +119,7 @@ def compare_versions_less_than(v1, v2):
         return i < j
     assert False, f"Can't compare versions {v1} and {v2}"
 
+
 def cleanup():
     deadline = time.time() + 5
     for p in child_processes:

--- a/yugabyte/run-jepsen.py
+++ b/yugabyte/run-jepsen.py
@@ -110,13 +110,13 @@ def get_workload_version(workload):
     assert False, f"Unanable to find workload in tests: {TESTS}"
 
 
-def is_versions_at_least(v_least, v_actual):
-    v_least_split = re.split('\.|-b', v_least)
+def is_versions_at_least(v_actual, v_least):
     v_actual_split = re.split('\.|-b', v_actual)
-    for i, j in zip_longest(map(int, v_least_split), map(int, v_actual_split), fillvalue=0):
+    v_least_split = re.split('\.|-b', v_least)
+    for i, j in zip_longest(map(int, v_actual_split), map(int, v_least_split), fillvalue=0):
         if i == j:
             continue
-        return i < j
+        return i > j
     return False
 
 
@@ -331,11 +331,11 @@ def main():
         iteration_cnt = 1
 
     workloads_to_skip = [workload for workload in args.workloads.split(',')
-                         if compare_versions_less_than(version,
-                                                       get_workload_version(workload))]
+                         if is_versions_at_least(version,
+                                                 get_workload_version(workload))]
     workloads_to_evaluate = [workload for workload in args.workloads.split(',')
-                             if not compare_versions_less_than(version,
-                                                               get_workload_version(workload))]
+                             if not is_versions_at_least(version,
+                                                         get_workload_version(workload))]
 
     if not workloads_to_evaluate:
         logging.error(f"No workloads for evaluate have been found because of version incompatibility\n"

--- a/yugabyte/run-jepsen.py
+++ b/yugabyte/run-jepsen.py
@@ -331,7 +331,7 @@ def main():
         iteration_cnt = 1
 
     all_workloads = args.workloads.split(',')
-    workloads_to_evaluate = [workload for workload in args.workloads.split(',')
+    workloads_to_evaluate = [workload for workload in all_workloads
                              if is_version_at_least(version,
                                                     get_workload_version(workload))]
     workloads_to_skip = set(all_workloads) - set(workloads_to_evaluate)

--- a/yugabyte/run-jepsen.py
+++ b/yugabyte/run-jepsen.py
@@ -77,7 +77,7 @@ TEST_PER_VERSION = [
         ]
     },
     {
-        "start_version": "2.13.1.0-b0",
+        "start_version": "2.13.1.0-b1",
         "tests": [
             "ysql/append-rc"
         ]
@@ -117,7 +117,7 @@ def is_version_at_least(v_least, v_actual):
         if i == j:
             continue
         return i < j
-    return False
+    return True
 
 
 def cleanup():
@@ -287,7 +287,7 @@ def main():
     atexit.register(cleanup)
 
     # Sort old results in the beginning if it did not happen at the end of the last run.
-    run_cmd(SORT_RESULTS_SH)
+    # run_cmd(SORT_RESULTS_SH)
 
     start_time = time.time()
     nemeses = args.nemeses
@@ -332,8 +332,8 @@ def main():
 
     all_workloads = args.workloads.split(',')
     workloads_to_evaluate = [workload for workload in all_workloads
-                             if not is_version_at_least(version,
-                                                        get_workload_version(workload))]
+                             if is_version_at_least(get_workload_version(workload),
+                                                    version)]
     workloads_to_skip = set(all_workloads) - set(workloads_to_evaluate)
 
     if not workloads_to_evaluate:

--- a/yugabyte/run-jepsen.py
+++ b/yugabyte/run-jepsen.py
@@ -52,7 +52,8 @@ DEFAULT_TARBALL_URL = "https://downloads.yugabyte.com/yugabyte-1.3.1.0-linux.tar
 
 TEST_PER_VERSION = [
     {
-        "2.4.0.0": [
+        "start_version": "2.4.0.0",
+        "tests": [
             "ycql/counter",
             "ycql/set",
             "ycql/set-index",
@@ -76,7 +77,8 @@ TEST_PER_VERSION = [
         ]
     },
     {
-        "2.13.1.0": [
+        "start_version": "2.13.1.0",
+        "tests": [
             "ysql/append-rc"
         ]
     }
@@ -101,9 +103,9 @@ child_processes = []
 
 def get_workload_version(workload):
     for el in TEST_PER_VERSION:
-        for version, tests in el.items():
+        for tests in el["tests"]:
             if workload in tests:
-                return version
+                return el["version"]
     assert False, f"Unanable to find workload in tests: {TESTS}"
 
 

--- a/yugabyte/run-jepsen.py
+++ b/yugabyte/run-jepsen.py
@@ -337,6 +337,12 @@ def main():
                              if not compare_versions_less_than(version,
                                                                get_workload_version(workload))]
 
+    if len(workloads_to_evaluate) == 0:
+        logging.error(f"No workloads for evaluate have been found\n"
+                      f"Should be skipped: {workloads_to_skip}\n"
+                      f"Workloads to evaluate: {workloads_to_evaluate}")
+        exit(1)
+
     for test in workloads_to_evaluate:
         for iteration in range(iteration_cnt):
             total_elapsed_time_sec = time.time() - start_time

--- a/yugabyte/run-jepsen.py
+++ b/yugabyte/run-jepsen.py
@@ -287,7 +287,7 @@ def main():
     atexit.register(cleanup)
 
     # Sort old results in the beginning if it did not happen at the end of the last run.
-    # run_cmd(SORT_RESULTS_SH)
+    run_cmd(SORT_RESULTS_SH)
 
     start_time = time.time()
     nemeses = args.nemeses

--- a/yugabyte/run-jepsen.py
+++ b/yugabyte/run-jepsen.py
@@ -110,7 +110,7 @@ def get_workload_version(workload):
     assert False, f"Unanable to find workload in tests: {TESTS}"
 
 
-def is_versions_at_least(v_actual, v_least):
+def is_version_at_least(v_actual, v_least):
     v_actual_split = re.split('\.|-b', v_actual)
     v_least_split = re.split('\.|-b', v_least)
     for i, j in zip_longest(map(int, v_actual_split), map(int, v_least_split), fillvalue=0):
@@ -331,11 +331,11 @@ def main():
         iteration_cnt = 1
 
     workloads_to_skip = [workload for workload in args.workloads.split(',')
-                         if is_versions_at_least(version,
-                                                 get_workload_version(workload))]
+                         if is_version_at_least(version,
+                                                get_workload_version(workload))]
     workloads_to_evaluate = [workload for workload in args.workloads.split(',')
-                             if not is_versions_at_least(version,
-                                                         get_workload_version(workload))]
+                             if not is_version_at_least(version,
+                                                        get_workload_version(workload))]
 
     if not workloads_to_evaluate:
         logging.error(f"No workloads for evaluate have been found because of version incompatibility\n"

--- a/yugabyte/run-jepsen.py
+++ b/yugabyte/run-jepsen.py
@@ -110,10 +110,10 @@ def get_workload_version(workload):
     assert False, f"Unanable to find workload in tests: {TESTS}"
 
 
-def compare_versions_less_than(v1, v2):
-    v1_split = re.split('\.|-b', v1)
-    v2_split = re.split('\.|-b', v2)
-    for i, j in zip_longest(map(int, v1_split), map(int, v2_split), fillvalue=0):
+def is_versions_at_least(v_least, v_actual):
+    v_least_split = re.split('\.|-b', v_least)
+    v_actual_split = re.split('\.|-b', v_actual)
+    for i, j in zip_longest(map(int, v_least_split), map(int, v_actual_split), fillvalue=0):
         if i == j:
             continue
         return i < j

--- a/yugabyte/src/yugabyte/auto.clj
+++ b/yugabyte/src/yugabyte/auto.clj
@@ -12,8 +12,7 @@
             [jepsen.control.net :as cn]
             [jepsen.control.util :as cu]
             [jepsen.os.debian :as debian]
-            [jepsen.os.centos :as centos]
-            [jepsen.reconnect :as rc]
+            [version-clj.core :as v]
             [yugabyte.ycql.client :as ycql.client]
             [yugabyte.ysql.client :as ysql.client]
             [slingshot.slingshot :refer [try+ throw+]])
@@ -27,6 +26,8 @@
 (def master-log-dir  (str dir "/master/logs"))
 (def tserver-log-dir (str dir "/tserver/logs"))
 (def installed-url-file (str dir "/installed-url"))
+
+(def minimal-read-committed-version "2.13.1.0-b1")
 
 (def max-bump-time-ops-per-test
   "Upper bound on number of bump time ops per test, needed to estimate max
@@ -409,6 +410,7 @@
             :--rpc_slow_query_threshold_ms 1000
             :--load_balancer_max_concurrent_adds 10
             (tserver-api-opts (:api test) node)
+            (tserver-version-specific test)
 
             ; Heartbeats
             ;:--heartbeat_interval_ms 100
@@ -419,7 +421,7 @@
             ;:--leader_failure_max_missed_heartbeat_period 3
             ;:--consensus_rpc_timeout_ms 300
             ;:--client_read_write_timeout_ms 6000
-            )))
+                                      )))
 
   (stop-master! [db]
     (c/su (cu/stop-daemon! ce-master-bin ce-master-pidfile)))

--- a/yugabyte/src/yugabyte/auto.clj
+++ b/yugabyte/src/yugabyte/auto.clj
@@ -321,7 +321,7 @@
      :--pgsql_proxy_bind_address (cn/ip node)]
     []))
 
-(defn tserver-workload-specific
+(defn tserver-workload-specific-opts
   "Version-specific flags"
   [test]
   (if (and (= (:workload test) :ysql/append-rc))
@@ -413,7 +413,7 @@
             :--rpc_slow_query_threshold_ms 1000
             :--load_balancer_max_concurrent_adds 10
             (tserver-api-opts (:api test) node)
-            (tserver-workload-specific test)
+            (tserver-workload-specific-opts test)
 
             ; Heartbeats
             ;:--heartbeat_interval_ms 100

--- a/yugabyte/src/yugabyte/auto.clj
+++ b/yugabyte/src/yugabyte/auto.clj
@@ -12,7 +12,8 @@
             [jepsen.control.net :as cn]
             [jepsen.control.util :as cu]
             [jepsen.os.debian :as debian]
-            [version-clj.core :as v]
+            [jepsen.os.centos :as centos]
+            [jepsen.reconnect :as rc]
             [yugabyte.ycql.client :as ycql.client]
             [yugabyte.ysql.client :as ysql.client]
             [slingshot.slingshot :refer [try+ throw+]])
@@ -26,8 +27,6 @@
 (def master-log-dir  (str dir "/master/logs"))
 (def tserver-log-dir (str dir "/tserver/logs"))
 (def installed-url-file (str dir "/installed-url"))
-
-(def minimal-read-committed-version "2.13.1.0-b1")
 
 (def max-bump-time-ops-per-test
   "Upper bound on number of bump time ops per test, needed to estimate max
@@ -321,7 +320,6 @@
   [api node]
   (if (= api :ysql)
     [:--start_pgsql_proxy
-     :--yb_enable_read_committed_isolation
      :--pgsql_proxy_bind_address (cn/ip node)]
     []))
 
@@ -410,7 +408,6 @@
             :--rpc_slow_query_threshold_ms 1000
             :--load_balancer_max_concurrent_adds 10
             (tserver-api-opts (:api test) node)
-            (tserver-version-specific test)
 
             ; Heartbeats
             ;:--heartbeat_interval_ms 100
@@ -421,7 +418,7 @@
             ;:--leader_failure_max_missed_heartbeat_period 3
             ;:--consensus_rpc_timeout_ms 300
             ;:--client_read_write_timeout_ms 6000
-                                      )))
+            )))
 
   (stop-master! [db]
     (c/su (cu/stop-daemon! ce-master-bin ce-master-pidfile)))

--- a/yugabyte/src/yugabyte/auto.clj
+++ b/yugabyte/src/yugabyte/auto.clj
@@ -12,7 +12,6 @@
             [jepsen.control.net :as cn]
             [jepsen.control.util :as cu]
             [jepsen.os.debian :as debian]
-            [version-clj.core :as v]
             [yugabyte.ycql.client :as ycql.client]
             [yugabyte.ysql.client :as ysql.client]
             [slingshot.slingshot :refer [try+ throw+]])
@@ -26,8 +25,6 @@
 (def master-log-dir  (str dir "/master/logs"))
 (def tserver-log-dir (str dir "/tserver/logs"))
 (def installed-url-file (str dir "/installed-url"))
-
-(def minimal-read-committed-version "2.13.1.0-b1")
 
 (def max-bump-time-ops-per-test
   "Upper bound on number of bump time ops per test, needed to estimate max

--- a/yugabyte/src/yugabyte/auto.clj
+++ b/yugabyte/src/yugabyte/auto.clj
@@ -424,7 +424,7 @@
             ;:--leader_failure_max_missed_heartbeat_period 3
             ;:--consensus_rpc_timeout_ms 300
             ;:--client_read_write_timeout_ms 6000
-                                      )))
+            )))
 
   (stop-master! [db]
     (c/su (cu/stop-daemon! ce-master-bin ce-master-pidfile)))


### PR DESCRIPTION
Since READ COMMITTED feature version we need version dependent logic to introduce.
After 2.13.1.0 version: append-rc test may be evaluated, otherwise it will be skipped

Changes include run_test.py script where we now have map with version and related tests (started from 2.4.0) and in Jepsen code also will add READ COMMITTED flag if append-rc test will be triggered

Log for version 2.13.0.0 append-rc only
```
~/workspace/github/jepsen/yugabyte$ python3 ./run-jepsen.py --nemeses partition --max-time-sec 21600 --url http://10.171.0.87:8080/yugabyte-2.12.1.0-b100-release-centos-x86_64.tar.gz --workloads ysql/append-rc --iterations 10
2022-05-18 17:35:15,143 [run-jepsen.py:174 INFO] Running command: /home/dsherstobitov/workspace/github/jepsen/yugabyte/sort-results.sh
2022-05-18 17:35:16,146 [run-jepsen.py:302 INFO] Directory /home/dsherstobitov/workspace/github/jepsen/yugabyte/logs already exists
2022-05-18 17:35:16,147 [run-jepsen.py:341 ERROR] No workloads for evaluate have been found
Should be skipped: ['ysql/append-rc']
Workloads to evaluate: []
```

If there is no workloads defined, then WARN message will be shown
```
~/workspace/github/jepsen/yugabyte$ python3 ./run-jepsen.py --nemeses partition --max-time-sec 21600 --url http://10.171.0.87:8080/yugabyte-2.12.1.0-b100-release-centos-x86_64.tar.gz --iterations 10
2022-05-18 16:59:00,409 [run-jepsen.py:174 INFO] Running command: /home/dsherstobitov/workspace/github/jepsen/yugabyte/sort-results.sh
2022-05-18 16:59:01,412 [run-jepsen.py:302 INFO] Directory /home/dsherstobitov/workspace/github/jepsen/yugabyte/logs already exists
2022-05-18 16:59:01,413 [run-jepsen.py:429 WARNING] Skipped workloads because of version incompatibility ['ysql/append-rc']
```

Log for version 2.13.1.0 version when we should evaluate workload
```
2022-03-21 19:22:24,742 [run-jepsen.py:173 INFO] Running command: lein run test --os debian --url http://debian10-gcp-jepsen-g587it:8080/yugabyte-2.13.1.0-b61-centos-x86_64.tar.gz --nemesis none --concurrency 4n --time-limit 600 --workload ysql/append-rc
2022-03-21 19:22:24,742 [run-jepsen.py:180 INFO] stdout log: /var/lib/jenkins/workspace/jepsen/yugabyte/logs/ysql-append-rc_nemesis_none_1_stdout.log
2022-03-21 19:22:24,742 [run-jepsen.py:181 INFO] stderr log: /var/lib/jenkins/workspace/jepsen/yugabyte/logs/ysql-append-rc_nemesis_none_1_stderr.log
2022-03-21 19:37:57,620 [run-jepsen.py:163 INFO] Last 30 lines of file 
...
Everything looks good! ヽ(‘ー`)ノ
```