### PR TITLE
Fixes for YCQL bank inserts scenario

### DIFF
--- a/yugabyte/src/yugabyte/bank_improved.clj
+++ b/yugabyte/src/yugabyte/bank_improved.clj
@@ -26,7 +26,7 @@
 (def start-key 0)
 (def end-key 5)
 
-(def insert-key-ctr (atom (+ end-key)))
+(def insert-key-ctr (atom (inc end-key)))
 (def contention-keys (range end-key (+ end-key 3)))
 
 (defn transfer-without-deletes

--- a/yugabyte/src/yugabyte/bank_improved.clj
+++ b/yugabyte/src/yugabyte/bank_improved.clj
@@ -26,7 +26,7 @@
 (def start-key 0)
 (def end-key 5)
 
-(def insert-key-ctr (atom end-key))
+(def insert-key-ctr (atom (+ end-key)))
 (def contention-keys (range end-key (+ end-key 3)))
 
 (defn transfer-without-deletes

--- a/yugabyte/src/yugabyte/ycql/bank_improved.clj
+++ b/yugabyte/src/yugabyte/ycql/bank_improved.clj
@@ -62,7 +62,7 @@
             conn
             (str "BEGIN TRANSACTION "
                  "INSERT INTO " keyspace "." table-name
-                 " (id, balance) VALUES (" to "," amount ");"
+                 " (id, balance) VALUES (" to "," amount ") IF NOT EXISTS;"
 
                  "UPDATE " keyspace "." table-name
                  " SET balance = balance - " amount " WHERE id = " from ";"

--- a/yugabyte/src/yugabyte/ycql/bank_improved.clj
+++ b/yugabyte/src/yugabyte/ycql/bank_improved.clj
@@ -62,7 +62,7 @@
             conn
             (str "BEGIN TRANSACTION "
                  "INSERT INTO " keyspace "." table-name
-                 " (id, balance) VALUES (" to "," amount ") IF NOT EXISTS;"
+                 " (id, balance) VALUES (" to "," amount ") IF NOT EXISTS ELSE ERROR;"
 
                  "UPDATE " keyspace "." table-name
                  " SET balance = balance - " amount " WHERE id = " from ";"


### PR DESCRIPTION
Added 2 small fixes to YCQL bank-inserts workload:
1. Increment key now starts from safe location (end-key + 1)
2. Added  `IF NOT EXISTS ELSE ERROR` clause to INSERT statement [because of this](https://docs.yugabyte.com/preview/api/ycql/dml_insert/), 
`By default INSERT has upsert semantics, that is, if the row already exists, it behaves like an UPDATE. If pure INSERT semantics is desired then the IF NOT EXISTS clause can be used to make sure an existing row is not overwritten by the INSERT.`