### PR TITLE
Added isolation prefixes and bank-si test

### DIFF
--- a/yugabyte/run-jepsen.py
+++ b/yugabyte/run-jepsen.py
@@ -54,32 +54,41 @@ TEST_PER_VERSION = [
     {
         "start_version": "1.3.1.0",
         "tests": [
-            "ycql/counter",
-            "ycql/set",
-            "ycql/set-index",
-            "ycql/bank",
-            "ycql/bank-inserts",
-            "ycql/long-fork",
-            "ycql/single-key-acid",
-            "ycql/multi-key-acid",
+            # YCQL snapshot isolation
+            "ycql/si.counter",
+            "ycql/si.set",
+            "ycql/si.set-index",
+            "ycql/si.bank",
+            "ycql/si.bank-inserts",
+            "ycql/si.long-fork",
+            "ycql/si.single-key-acid",
+            "ycql/si.multi-key-acid",
 
-            "ysql/counter",
-            "ysql/set",
-            "ysql/bank",
-            "ysql/bank-contention",
-            "ysql/bank-multitable",
-            "ysql/long-fork",
-            "ysql/single-key-acid",
-            "ysql/multi-key-acid",
-            "ysql/append",
-            "ysql/append-si",
-            "ysql/default-value",
+
+            # YSQL serializable
+            "ysql/sz.counter",
+            "ysql/sz.set",
+            "ysql/sz.bank",
+            "ysql/sz.bank-contention",
+            "ysql/sz.bank-multitable",
+            "ysql/sz.long-fork",
+            "ysql/sz.single-key-acid",
+            "ysql/sz.multi-key-acid",
+            "ysql/sz.default-value",
+            "ysql/sz.append",
+
+            # YSQL snapshot isolation
+            "ysql/si.append-si",
+            "ysql/si.bank",
+            "ysql/si.bank-contention",
+            "ysql/si.bank-multitable",
         ]
     },
     {
         "start_version": "2.13.1.0-b1",
         "tests": [
-            "ysql/append-rc"
+            # YSQL read committed
+            "ysql/rc.append"
         ]
     }
 ]

--- a/yugabyte/run-jepsen.py
+++ b/yugabyte/run-jepsen.py
@@ -55,14 +55,14 @@ TEST_PER_VERSION = [
         "start_version": "1.3.1.0",
         "tests": [
             # YCQL snapshot isolation
-            "ycql/si.counter",
-            "ycql/si.set",
-            "ycql/si.set-index",
-            "ycql/si.bank",
-            "ycql/si.bank-inserts",
-            "ycql/si.long-fork",
-            "ycql/si.single-key-acid",
-            "ycql/si.multi-key-acid",
+            "ycql/counter",
+            "ycql/set",
+            "ycql/set-index",
+            "ycql/bank",
+            "ycql/bank-inserts",
+            "ycql/long-fork",
+            "ycql/single-key-acid",
+            "ycql/multi-key-acid",
 
 
             # YSQL serializable

--- a/yugabyte/src/yugabyte/core.clj
+++ b/yugabyte/src/yugabyte/core.clj
@@ -78,39 +78,42 @@
 (def workloads-ycql
   "A map of workload names to functions that can take option maps and construct workloads."
   #:ycql{:none            noop-test
-         :counter         (with-client counter/workload (yugabyte.ycql.counter/->CQLCounterClient))
-         :set             (with-client set/workload (yugabyte.ycql.set/->CQLSetClient))
-         :set-index       (with-client set/workload (yugabyte.ycql.set/->CQLSetIndexClient))
-         :bank            (with-client bank/workload-allow-neg (yugabyte.ycql.bank/->CQLBank))
-         :bank-inserts    (with-client bank-improved/workload-with-inserts (yugabyte.ycql.bank-improved/->CQLBankImproved))
+         :si.counter         (with-client counter/workload (yugabyte.ycql.counter/->CQLCounterClient))
+         :si.set             (with-client set/workload (yugabyte.ycql.set/->CQLSetClient))
+         :si.set-index       (with-client set/workload (yugabyte.ycql.set/->CQLSetIndexClient))
+         :si.bank            (with-client bank/workload-allow-neg (yugabyte.ycql.bank/->CQLBank))
+         :si.bank-inserts    (with-client bank-improved/workload-with-inserts (yugabyte.ycql.bank-improved/->CQLBankImproved))
          ; Shouldn't be used until we support transactions with selects.
          ; :bank-multitable (with-client bank/workload-allow-neg (yugabyte.ycql.bank/->CQLMultiBank))
-         :long-fork       (with-client long-fork/workload (yugabyte.ycql.long-fork/->CQLLongForkIndexClient))
-         :single-key-acid (with-client single-key-acid/workload (yugabyte.ycql.single-key-acid/->CQLSingleKey))
-         :multi-key-acid  (with-client multi-key-acid/workload (yugabyte.ycql.multi-key-acid/->CQLMultiKey))})
+         :si.long-fork       (with-client long-fork/workload (yugabyte.ycql.long-fork/->CQLLongForkIndexClient))
+         :si.single-key-acid (with-client single-key-acid/workload (yugabyte.ycql.single-key-acid/->CQLSingleKey))
+         :si.multi-key-acid  (with-client multi-key-acid/workload (yugabyte.ycql.multi-key-acid/->CQLMultiKey))})
 
 (def workloads-ysql
   "A map of workload names to functions that can take option maps and construct workloads."
-  #:ysql{:none            noop-test
-         :sleep           sleep-test
-         :counter         (with-client counter/workload (yugabyte.ysql.counter/->YSQLCounterClient))
-         :set             (with-client set/workload (yugabyte.ysql.set/->YSQLSetClient))
+  #:ysql{:none               noop-test
+         :sz.sleep           sleep-test
+         :sz.counter         (with-client counter/workload (yugabyte.ysql.counter/->YSQLCounterClient))
+         :sz.set             (with-client set/workload (yugabyte.ysql.set/->YSQLSetClient))
          ; This one doesn't work because of https://github.com/YugaByte/yugabyte-db/issues/1554
          ; :set-index       (with-client set/workload (yugabyte.ysql.set/->YSQLSetIndexClient))
          ; We'd rather allow negatives for now because it makes reproducing error easier
-         :bank            (with-client bank/workload-allow-neg (yugabyte.ysql.bank/->YSQLBankClient true))
-         :bank-multitable (with-client bank/workload-allow-neg (yugabyte.ysql.bank/->YSQLMultiBankClient true))
-         :bank-contention (with-client bank-improved/workload-contention-keys (yugabyte.ysql.bank-improved/->YSQLBankContentionClient))
-         :long-fork       (with-client long-fork/workload (yugabyte.ysql.long-fork/->YSQLLongForkClient))
-         :single-key-acid (with-client single-key-acid/workload (yugabyte.ysql.single-key-acid/->YSQLSingleKeyAcidClient))
-         :multi-key-acid  (with-client multi-key-acid/workload (yugabyte.ysql.multi-key-acid/->YSQLMultiKeyAcidClient))
-         :append-rc       (with-client append/workload-rc (ysql.append/->Client :read-committed))
+         :sz.bank            (with-client bank/workload-allow-neg (yugabyte.ysql.bank/->YSQLBankClient true :serializable))
+         :sz.bank-multitable (with-client bank/workload-allow-neg (yugabyte.ysql.bank/->YSQLMultiBankClient true :serializable))
+         :sz.bank-contention (with-client bank-improved/workload-contention-keys (yugabyte.ysql.bank-improved/->YSQLBankContentionClient :serializable))
+         :sz.long-fork       (with-client long-fork/workload (yugabyte.ysql.long-fork/->YSQLLongForkClient))
+         :sz.single-key-acid (with-client single-key-acid/workload (yugabyte.ysql.single-key-acid/->YSQLSingleKeyAcidClient))
+         :sz.multi-key-acid  (with-client multi-key-acid/workload (yugabyte.ysql.multi-key-acid/->YSQLMultiKeyAcidClient))
+         :sz.append          (with-client append/workload-serializable (ysql.append/->Client :serializable))
+         :sz.append-table    (with-client append/workload-serializable (ysql.append-table/->Client :serializable))
+         :sz.default-value   (with-client default-value/workload (ysql.default-value/->Client))
+         :rc.append          (with-client append/workload-rc (ysql.append/->Client :read-committed))
          ; See https://docs.yugabyte.com/latest/architecture/transactions/isolation-levels/
          ; :snapshot-isolation maps to :repeatable_read SQL
-         :append-si       (with-client append/workload-si (ysql.append/->Client :repeatable-read))
-         :append          (with-client append/workload-serializable (ysql.append/->Client :serializable))
-         :append-table    (with-client append/workload-serializable (ysql.append-table/->Client :serializable))
-         :default-value   (with-client default-value/workload (ysql.default-value/->Client))})
+         :si.append          (with-client append/workload-si (ysql.append/->Client :repeatable-read))
+         :si.bank            (with-client append/workload-si (ysql.append/->Client :repeatable-read))
+         :si.bank-multitable (with-client append/workload-si (ysql.append/->Client :repeatable-read))
+         :si.bank-contention (with-client append/workload-si (ysql.append/->Client :repeatable-read))})
 
 (def workloads
   (merge workloads-ycql workloads-ysql))

--- a/yugabyte/src/yugabyte/core.clj
+++ b/yugabyte/src/yugabyte/core.clj
@@ -92,7 +92,7 @@
 (def workloads-ysql
   "A map of workload names to functions that can take option maps and construct workloads."
   #:ysql{:none               noop-test
-         :sz.sleep           sleep-test
+         :sleep              sleep-test
          :sz.counter         (with-client counter/workload (yugabyte.ysql.counter/->YSQLCounterClient))
          :sz.set             (with-client set/workload (yugabyte.ysql.set/->YSQLSetClient))
          ; This one doesn't work because of https://github.com/YugaByte/yugabyte-db/issues/1554

--- a/yugabyte/src/yugabyte/core.clj
+++ b/yugabyte/src/yugabyte/core.clj
@@ -78,16 +78,16 @@
 (def workloads-ycql
   "A map of workload names to functions that can take option maps and construct workloads."
   #:ycql{:none            noop-test
-         :si.counter         (with-client counter/workload (yugabyte.ycql.counter/->CQLCounterClient))
-         :si.set             (with-client set/workload (yugabyte.ycql.set/->CQLSetClient))
-         :si.set-index       (with-client set/workload (yugabyte.ycql.set/->CQLSetIndexClient))
-         :si.bank            (with-client bank/workload-allow-neg (yugabyte.ycql.bank/->CQLBank))
-         :si.bank-inserts    (with-client bank-improved/workload-with-inserts (yugabyte.ycql.bank-improved/->CQLBankImproved))
+         :counter         (with-client counter/workload (yugabyte.ycql.counter/->CQLCounterClient))
+         :set             (with-client set/workload (yugabyte.ycql.set/->CQLSetClient))
+         :set-index       (with-client set/workload (yugabyte.ycql.set/->CQLSetIndexClient))
+         :bank            (with-client bank/workload-allow-neg (yugabyte.ycql.bank/->CQLBank))
+         :bank-inserts    (with-client bank-improved/workload-with-inserts (yugabyte.ycql.bank-improved/->CQLBankImproved))
          ; Shouldn't be used until we support transactions with selects.
          ; :bank-multitable (with-client bank/workload-allow-neg (yugabyte.ycql.bank/->CQLMultiBank))
-         :si.long-fork       (with-client long-fork/workload (yugabyte.ycql.long-fork/->CQLLongForkIndexClient))
-         :si.single-key-acid (with-client single-key-acid/workload (yugabyte.ycql.single-key-acid/->CQLSingleKey))
-         :si.multi-key-acid  (with-client multi-key-acid/workload (yugabyte.ycql.multi-key-acid/->CQLMultiKey))})
+         :long-fork       (with-client long-fork/workload (yugabyte.ycql.long-fork/->CQLLongForkIndexClient))
+         :single-key-acid (with-client single-key-acid/workload (yugabyte.ycql.single-key-acid/->CQLSingleKey))
+         :multi-key-acid  (with-client multi-key-acid/workload (yugabyte.ycql.multi-key-acid/->CQLMultiKey))})
 
 (def workloads-ysql
   "A map of workload names to functions that can take option maps and construct workloads."

--- a/yugabyte/src/yugabyte/ysql/bank.clj
+++ b/yugabyte/src/yugabyte/ysql/bank.clj
@@ -20,7 +20,7 @@
        (map (juxt :id :balance))
        (into (sorted-map))))
 
-(defrecord YSQLBankYbClient [allow-negatives?]
+(defrecord YSQLBankYbClient [allow-negatives? isolation]
   c/YSQLYbClient
 
   (setup-cluster! [this test c conn-wrapper]
@@ -41,8 +41,7 @@
       (assoc op :type :ok, :value (read-accounts-map op c))
 
       :transfer
-      (c/with-txn
-        c
+      (j/with-db-transaction [c c {:isolation isolation}]
         (let [{:keys [from to amount]} (:value op)]
           (let [b-from-before (c/select-single-value op c table-name :balance (str "id = " from))
                 b-to-before   (c/select-single-value op c table-name :balance (str "id = " to))
@@ -67,7 +66,7 @@
 ; Multi-table bank test
 ;
 
-(defrecord YSQLMultiBankYbClient [allow-negatives?]
+(defrecord YSQLMultiBankYbClient [allow-negatives? isolation]
   c/YSQLYbClient
 
   (setup-cluster! [this test c conn-wrapper]
@@ -101,8 +100,7 @@
 
       :transfer
       (let [{:keys [from to amount]} (:value op)]
-        (c/with-txn
-          c
+        (j/with-db-transaction [c c {:isolation isolation}]
           (let [b-from-before (c/select-single-value op c (str table-name from) :balance (str "id = " from))
                 b-to-before   (c/select-single-value op c (str table-name to) :balance (str "id = " to))
                 b-from-after  (- b-from-before amount)

--- a/yugabyte/src/yugabyte/ysql/bank.clj
+++ b/yugabyte/src/yugabyte/ysql/bank.clj
@@ -89,8 +89,7 @@
   (invoke-op! [this test op c conn-wrapper]
     (case (:f op)
       :read
-      (c/with-txn
-        c
+      ((j/with-db-transaction [c c {:isolation isolation}]
         (let [accs (shuffle (:accounts test))]
           (->> accs
                (mapv (fn [a]

--- a/yugabyte/src/yugabyte/ysql/bank_improved.clj
+++ b/yugabyte/src/yugabyte/ysql/bank_improved.clj
@@ -48,7 +48,8 @@
   (invoke-op! [this test op c conn-wrapper]
     (case (:f op)
       :read
-      (assoc op :type :ok, :value (read-accounts-map test op c))
+      (j/with-db-transaction [c c {:isolation isolation}]
+        (assoc op :type :ok, :value (read-accounts-map test op c)))
 
       :update
       (j/with-db-transaction [c c {:isolation isolation}]


### PR DESCRIPTION
Added prefix for each test, to define transaction isolation that will be used there.
sz - serialisable 
si - snapshot isolation
rc - read committed

For example, old `ysql/bank` now will be `ysql/sz.bank`, all YCQL tests are `si.*TEST*`