### PR TITLE
Syntax fix for bank.clj and removed load_balancer_max_concurrent_adds

### DIFF
--- a/yugabyte/src/yugabyte/auto.clj
+++ b/yugabyte/src/yugabyte/auto.clj
@@ -393,6 +393,7 @@
               experimental-tuning-flags)
             :--master_addresses (master-addresses test)
             :--replication_factor (:replication-factor test)
+            :--load_balancer_max_concurrent_adds 10
             (master-api-opts (:api test) node)
             )))
 
@@ -411,6 +412,7 @@
             ; Tracing
             :--enable_tracing
             :--rpc_slow_query_threshold_ms 1000
+            ;:--load_balancer_max_concurrent_adds 10
             (tserver-api-opts (:api test) node)
             (tserver-workload-specific-opts test)
 

--- a/yugabyte/src/yugabyte/auto.clj
+++ b/yugabyte/src/yugabyte/auto.clj
@@ -411,7 +411,7 @@
             ; Tracing
             :--enable_tracing
             :--rpc_slow_query_threshold_ms 1000
-            ;:--load_balancer_max_concurrent_adds 10
+            :--load_balancer_max_concurrent_adds 10
             (tserver-api-opts (:api test) node)
             (tserver-workload-specific-opts test)
 

--- a/yugabyte/src/yugabyte/auto.clj
+++ b/yugabyte/src/yugabyte/auto.clj
@@ -411,7 +411,7 @@
             ; Tracing
             :--enable_tracing
             :--rpc_slow_query_threshold_ms 1000
-            :--load_balancer_max_concurrent_adds 10
+            ;:--load_balancer_max_concurrent_adds 10
             (tserver-api-opts (:api test) node)
             (tserver-workload-specific-opts test)
 

--- a/yugabyte/src/yugabyte/auto.clj
+++ b/yugabyte/src/yugabyte/auto.clj
@@ -393,7 +393,6 @@
               experimental-tuning-flags)
             :--master_addresses (master-addresses test)
             :--replication_factor (:replication-factor test)
-            :--load_balancer_max_concurrent_adds 10
             (master-api-opts (:api test) node)
             )))
 
@@ -412,7 +411,6 @@
             ; Tracing
             :--enable_tracing
             :--rpc_slow_query_threshold_ms 1000
-            ;:--load_balancer_max_concurrent_adds 10
             (tserver-api-opts (:api test) node)
             (tserver-workload-specific-opts test)
 

--- a/yugabyte/src/yugabyte/auto.clj
+++ b/yugabyte/src/yugabyte/auto.clj
@@ -411,7 +411,6 @@
             ; Tracing
             :--enable_tracing
             :--rpc_slow_query_threshold_ms 1000
-            :--load_balancer_max_concurrent_adds 10
             (tserver-api-opts (:api test) node)
             (tserver-workload-specific-opts test)
 

--- a/yugabyte/src/yugabyte/ysql/bank.clj
+++ b/yugabyte/src/yugabyte/ysql/bank.clj
@@ -89,7 +89,7 @@
   (invoke-op! [this test op c conn-wrapper]
     (case (:f op)
       :read
-      ((j/with-db-transaction [c c {:isolation isolation}]
+      (j/with-db-transaction [c c {:isolation isolation}]
         (let [accs (shuffle (:accounts test))]
           (->> accs
                (mapv (fn [a]


### PR DESCRIPTION
Fixed syntax error in bank.clj
Removed load_balancer_max_concurrent_adds from tserver flags, since it didn't worked and in master build cause failure.