### PR TITLE
Disabled YCQL bank-inserts

### DIFF
--- a/yugabyte/run-jepsen.py
+++ b/yugabyte/run-jepsen.py
@@ -62,7 +62,8 @@ TEST_PER_VERSION = [
             "ycql/long-fork",
             "ycql/single-key-acid",
             "ycql/multi-key-acid",
-            # Disabled
+            # Disabled https://github.com/yugabyte/yugabyte-db/issues/10328
+            # Related to multipage index scan https://github.com/yugabyte/yugabyte-db/issues/13502
             # "ycql/bank-inserts",
 
 

--- a/yugabyte/run-jepsen.py
+++ b/yugabyte/run-jepsen.py
@@ -59,10 +59,11 @@ TEST_PER_VERSION = [
             "ycql/set",
             "ycql/set-index",
             "ycql/bank",
-            "ycql/bank-inserts",
             "ycql/long-fork",
             "ycql/single-key-acid",
             "ycql/multi-key-acid",
+            # Disabled
+            # "ycql/bank-inserts",
 
 
             # YSQL serializable


### PR DESCRIPTION
We don’t give cross-row atomicity on reads in YCQL.