### PR TITLE
Fixed process killing code

### DIFF
--- a/yugabyte/src/yugabyte/auto.clj
+++ b/yugabyte/src/yugabyte/auto.clj
@@ -427,10 +427,10 @@
             )))
 
   (stop-master! [db]
-    (c/su (cu/stop-daemon! ce-master-bin ce-master-pidfile)))
+    (c/su (cu/grepkill! ce-master-bin)))
 
   (stop-tserver! [db]
-    (c/su (cu/stop-daemon! ce-tserver-bin ce-tserver-pidfile))
+    (c/su (cu/grepkill! ce-tserver-bin))
     (c/su (cu/grepkill! "postgres")))
 
   (wipe! [db]


### PR DESCRIPTION
In current yugabyte-db master branch master and tserver processed has been merged into a single execution file. This leads to the behaviour when kill-all will kill all yugabyte processes. 
This fix will assume this behaviour.