### PR TITLE
Geo partitioning append tests and API

### DIFF
--- a/yugabyte/project.clj
+++ b/yugabyte/project.clj
@@ -8,6 +8,7 @@
                  [jepsen "0.3.1"]
                  [com.yugabyte/cassaforte "3.0.0-alpha2-yb-1"]
                  [org.clojure/java.jdbc "0.7.12"]
+                 [org.clojure/data.json "2.4.0"]
                  [org.postgresql/postgresql "42.5.1"]
                  [version-clj "2.0.2"]
                  [clj-wallhack "1.0.1"]]

--- a/yugabyte/run-jepsen.py
+++ b/yugabyte/run-jepsen.py
@@ -81,9 +81,11 @@ TEST_PER_VERSION = [
             "ysql/sz.multi-key-acid",
             "ysql/sz.default-value",
             "ysql/sz.ol.append",
+            "ysql/sz.ol.geo.append",
 
             # YSQL snapshot isolation
             "ysql/si.ol.append",
+            "ysql/si.ol.geo.append",
             "ysql/si.bank",
             "ysql/si.bank-contention",
             "ysql/si.bank-multitable",
@@ -94,14 +96,18 @@ TEST_PER_VERSION = [
         "tests": [
             # YSQL read committed
             "ysql/rc.ol.append",
+            "ysql/rc.ol.geo.append",
             "ysql/rc.pl.append",
+            "ysql/rc.pl.geo.append",
         ]
     },
     {
         "start_version": "2.17.2.0-b1",
         "tests": [
             "ysql/sz.pl.append",
+            "ysql/sz.pl.geo.append",
             "ysql/si.pl.append",
+            "ysql/si.pl.geo.append",
         ]
     }
 ]

--- a/yugabyte/src/yugabyte/auto.clj
+++ b/yugabyte/src/yugabyte/auto.clj
@@ -460,7 +460,7 @@
             :--master_addresses (master-addresses test)
             :--replication_factor (:replication-factor test)
             (master-tserver-experimental-tuning-flags test)
-            (master-tserver-random-clock-skew test node)
+            ;(master-tserver-random-clock-skew test node)
             (master-tserver-wait-on-conflict-flags test)
             ;(master-tserver-geo-partitioning-flags test node (:nodes test))
             (master-api-opts (:api test) node)
@@ -480,7 +480,7 @@
             :--enable_tracing
             :--rpc_slow_query_threshold_ms 1000
             (master-tserver-experimental-tuning-flags test)
-            (master-tserver-random-clock-skew test node)
+            ;(master-tserver-random-clock-skew test node)
             (master-tserver-wait-on-conflict-flags test)
             ;(master-tserver-geo-partitioning-flags test node (:nodes test))
             (tserver-api-opts (:api test) node)

--- a/yugabyte/src/yugabyte/auto.clj
+++ b/yugabyte/src/yugabyte/auto.clj
@@ -363,7 +363,7 @@
 
 (defn get-random-node-geo
   [count_nodes node_ip]
-  (rand-int count_nodes))
+  (+ 1 (rand-int count_nodes)))
 
 (def get-node-geo
   (memoize get-random-node-geo))
@@ -372,8 +372,7 @@
   "Geo partitioning specific flags"
   [test node nodes]
   (if (clojure.string/includes? (name (:workload test)) "geo.")
-    ; todo in geo append test we using 3 zones
-    (let [node-id-int (get-node-geo 3 (cn/ip node))]
+    (let [node-id-int (get-node-geo 2 (cn/ip node))]
       [:--placement_cloud :gcp
        :--placement_region (str "jepsen-" node-id-int)
        :--placement_zone (str "jepsen-" node-id-int "a")])

--- a/yugabyte/src/yugabyte/auto.clj
+++ b/yugabyte/src/yugabyte/auto.clj
@@ -459,7 +459,7 @@
             (ce-shared-opts node)
             :--master_addresses (master-addresses test)
             :--replication_factor (:replication-factor test)
-            :--auto_create_local_transaction_tables :false
+            :--auto_create_local_transaction_tables=false
             (master-tserver-experimental-tuning-flags test)
             ;(master-tserver-random-clock-skew test node)
             (master-tserver-wait-on-conflict-flags test)

--- a/yugabyte/src/yugabyte/auto.clj
+++ b/yugabyte/src/yugabyte/auto.clj
@@ -461,7 +461,7 @@
             :--replication_factor (:replication-factor test)
             :--auto_create_local_transaction_tables=false
             (master-tserver-experimental-tuning-flags test)
-            ;(master-tserver-random-clock-skew test node)
+            (master-tserver-random-clock-skew test node)
             (master-tserver-wait-on-conflict-flags test)
             (master-tserver-geo-partitioning-flags test node (:nodes test))
             (master-api-opts (:api test) node)
@@ -481,7 +481,7 @@
             :--enable_tracing
             :--rpc_slow_query_threshold_ms 1000
             (master-tserver-experimental-tuning-flags test)
-            ;(master-tserver-random-clock-skew test node)
+            (master-tserver-random-clock-skew test node)
             (master-tserver-wait-on-conflict-flags test)
             (master-tserver-geo-partitioning-flags test node (:nodes test))
             (tserver-api-opts (:api test) node)
@@ -515,6 +515,7 @@
   db/Primary
   (setup-primary! [this test node]
     "Executed once on a first node in list (i.e. n1 by default) after per-node setup is done"
+    ; NOOP placeholder, can be used to initialize cluster for different APIs
     )
 
   db/LogFiles

--- a/yugabyte/src/yugabyte/auto.clj
+++ b/yugabyte/src/yugabyte/auto.clj
@@ -459,6 +459,7 @@
             (ce-shared-opts node)
             :--master_addresses (master-addresses test)
             :--replication_factor (:replication-factor test)
+            :--auto_create_local_transaction_tables
             (master-tserver-experimental-tuning-flags test)
             ;(master-tserver-random-clock-skew test node)
             (master-tserver-wait-on-conflict-flags test)
@@ -479,6 +480,7 @@
             ; Tracing
             :--enable_tracing
             :--rpc_slow_query_threshold_ms 1000
+            :--auto_create_local_transaction_tables
             (master-tserver-experimental-tuning-flags test)
             ;(master-tserver-random-clock-skew test node)
             (master-tserver-wait-on-conflict-flags test)
@@ -514,14 +516,6 @@
   db/Primary
   (setup-primary! [this test node]
     "Executed once on a first node in list (i.e. n1 by default) after per-node setup is done"
-    (if (clojure.string/includes? (name (:workload test)) "geo.")
-      (do
-        (info "Creating transactional table " :transactions_jepsen_1)
-        (yb-admin test :create_transaction_table :transactions_jepsen_1)
-        (yb-admin test :modify_table_placement_info :system :transactions_jepsen_1 "ybc.jepsen-1.jepsen-1a" 2)
-        (info "Creating transactional table " :transactions_jepsen_2)
-        (yb-admin test :create_transaction_table :transactions_jepsen_2)
-        (yb-admin test :modify_table_placement_info :system :transactions_jepsen_2 "ybc.jepsen-2.jepsen-2a" 2)))
     )
 
   db/LogFiles

--- a/yugabyte/src/yugabyte/auto.clj
+++ b/yugabyte/src/yugabyte/auto.clj
@@ -201,10 +201,10 @@
 
   (if (clojure.string/includes? (name (:workload test)) "geo.")
     (do
-      (yugabyte.auto/yb-admin test :create_transaction_table :jepsen_1_transactions)
-      (yugabyte.auto/yb-admin test :modify_table_placement_info :system :jepsen_1_transactions "gcp.jepsen-1.jepsen-1a" 3)
-      (yugabyte.auto/yb-admin test :create_transaction_table :jepsen_2_transactions)
-      (yugabyte.auto/yb-admin test :modify_table_placement_info :system :jepsen_2_transactions "gcp.jepsen-2.jepsen-2a" 3)))
+      (yugabyte.auto/yb-admin test :create_transaction_table :transactions_jepsen_1)
+      (yugabyte.auto/yb-admin test :modify_table_placement_info :system :transactions_jepsen_1 "gcp.jepsen-1.jepsen-1a" 3)
+      (yugabyte.auto/yb-admin test :create_transaction_table :transactions_jepsen_2)
+      (yugabyte.auto/yb-admin test :modify_table_placement_info :system :transactions_jepsen_2 "gcp.jepsen-2.jepsen-2a" 3)))
 
   :started)
 

--- a/yugabyte/src/yugabyte/auto.clj
+++ b/yugabyte/src/yugabyte/auto.clj
@@ -459,6 +459,7 @@
             (ce-shared-opts node)
             :--master_addresses (master-addresses test)
             :--replication_factor (:replication-factor test)
+            :--sql_log_statement :all
             (master-tserver-experimental-tuning-flags test)
             (master-tserver-random-clock-skew test node)
             (master-tserver-wait-on-conflict-flags test)

--- a/yugabyte/src/yugabyte/auto.clj
+++ b/yugabyte/src/yugabyte/auto.clj
@@ -518,9 +518,9 @@
     (if (clojure.string/includes? (name (:workload test)) "geo.")
       (do
         (yugabyte.auto/yb-admin test :create_transaction_table :transactions_jepsen_1)
-        (yugabyte.auto/yb-admin test :modify_table_placement_info :system :transactions_jepsen_1 "gcp.jepsen-1.jepsen-1a" 3)
+        (yugabyte.auto/yb-admin test :modify_table_placement_info :system :transactions_jepsen_1 "gcp.jepsen-1.jepsen-1a" 2)
         (yugabyte.auto/yb-admin test :create_transaction_table :transactions_jepsen_2)
-        (yugabyte.auto/yb-admin test :modify_table_placement_info :system :transactions_jepsen_2 "gcp.jepsen-2.jepsen-2a" 3)))
+        (yugabyte.auto/yb-admin test :modify_table_placement_info :system :transactions_jepsen_2 "gcp.jepsen-2.jepsen-2a" 2)))
     )
 
   db/LogFiles

--- a/yugabyte/src/yugabyte/auto.clj
+++ b/yugabyte/src/yugabyte/auto.clj
@@ -459,7 +459,7 @@
             (ce-shared-opts node)
             :--master_addresses (master-addresses test)
             :--replication_factor (:replication-factor test)
-            :--sql_log_statement :all
+            :--ysql_log_statement :all
             (master-tserver-experimental-tuning-flags test)
             (master-tserver-random-clock-skew test node)
             (master-tserver-wait-on-conflict-flags test)
@@ -477,8 +477,7 @@
             ce-tserver-bin
             (ce-shared-opts node)
             :--tserver_master_addrs (master-addresses test)
-
-            :--sql_log_statement :all
+            :--ysql_log_statement :all
             ; Tracing
             :--enable_tracing
             :--rpc_slow_query_threshold_ms 1000

--- a/yugabyte/src/yugabyte/auto.clj
+++ b/yugabyte/src/yugabyte/auto.clj
@@ -459,7 +459,6 @@
             (ce-shared-opts node)
             :--master_addresses (master-addresses test)
             :--replication_factor (:replication-factor test)
-            :--auto_create_local_transaction_tables
             (master-tserver-experimental-tuning-flags test)
             ;(master-tserver-random-clock-skew test node)
             (master-tserver-wait-on-conflict-flags test)
@@ -480,7 +479,6 @@
             ; Tracing
             :--enable_tracing
             :--rpc_slow_query_threshold_ms 1000
-            :--auto_create_local_transaction_tables
             (master-tserver-experimental-tuning-flags test)
             ;(master-tserver-random-clock-skew test node)
             (master-tserver-wait-on-conflict-flags test)

--- a/yugabyte/src/yugabyte/auto.clj
+++ b/yugabyte/src/yugabyte/auto.clj
@@ -514,11 +514,11 @@
     (if (clojure.string/includes? (name (:workload test)) "geo.")
       (do
         (info "Creating transactional table " :transactions_jepsen_1)
-        (yugabyte.auto/yb-admin test :create_transaction_table :transactions_jepsen_1)
-        (yugabyte.auto/yb-admin test :modify_table_placement_info :system :transactions_jepsen_1 "ybc.jepsen-1.jepsen-1a" 2)
+        (yb-admin test :create_transaction_table :transactions_jepsen_1)
+        (yb-admin test :modify_table_placement_info :system :transactions_jepsen_1 "ybc.jepsen-1.jepsen-1a" 2)
         (info "Creating transactional table " :transactions_jepsen_2)
-        (yugabyte.auto/yb-admin test :create_transaction_table :transactions_jepsen_2)
-        (yugabyte.auto/yb-admin test :modify_table_placement_info :system :transactions_jepsen_2 "ybc.jepsen-2.jepsen-2a" 2)))
+        (yb-admin test :create_transaction_table :transactions_jepsen_2)
+        (yb-admin test :modify_table_placement_info :system :transactions_jepsen_2 "ybc.jepsen-2.jepsen-2a" 2)))
     )
 
   db/LogFiles

--- a/yugabyte/src/yugabyte/auto.clj
+++ b/yugabyte/src/yugabyte/auto.clj
@@ -462,7 +462,7 @@
             (master-tserver-experimental-tuning-flags test)
             ;(master-tserver-random-clock-skew test node)
             (master-tserver-wait-on-conflict-flags test)
-            ;(master-tserver-geo-partitioning-flags test node (:nodes test))
+            (master-tserver-geo-partitioning-flags test node (:nodes test))
             (master-api-opts (:api test) node)
             )))
 
@@ -482,7 +482,7 @@
             (master-tserver-experimental-tuning-flags test)
             ;(master-tserver-random-clock-skew test node)
             (master-tserver-wait-on-conflict-flags test)
-            ;(master-tserver-geo-partitioning-flags test node (:nodes test))
+            (master-tserver-geo-partitioning-flags test node (:nodes test))
             (tserver-api-opts (:api test) node)
             (tserver-read-committed-flags test)
             (tserver-heartbeat-flags test)

--- a/yugabyte/src/yugabyte/auto.clj
+++ b/yugabyte/src/yugabyte/auto.clj
@@ -462,7 +462,7 @@
             (master-tserver-experimental-tuning-flags test)
             (master-tserver-random-clock-skew test node)
             (master-tserver-wait-on-conflict-flags test)
-            (master-tserver-geo-partitioning-flags test)
+            (master-tserver-geo-partitioning-flags test node (:nodes test))
             (master-api-opts (:api test) node)
             )))
 
@@ -482,7 +482,7 @@
             (master-tserver-experimental-tuning-flags test)
             (master-tserver-random-clock-skew test node)
             (master-tserver-wait-on-conflict-flags test)
-            (master-tserver-geo-partitioning-flags test)
+            (master-tserver-geo-partitioning-flags test node (:nodes test))
             (tserver-api-opts (:api test) node)
             (tserver-read-committed-flags test)
             (tserver-heartbeat-flags test)

--- a/yugabyte/src/yugabyte/auto.clj
+++ b/yugabyte/src/yugabyte/auto.clj
@@ -515,7 +515,12 @@
   db/Primary
   (setup-primary! [this test node]
     "Executed once on a first node in list (i.e. n1 by default) after per-node setup is done"
-    ; NOOP placeholder, can be used to initialize cluster for different APIs
+    (if (clojure.string/includes? (name (:workload test)) "geo.")
+      (do
+        (yugabyte.auto/yb-admin test :create_transaction_table :transactions_jepsen_1)
+        (yugabyte.auto/yb-admin test :modify_table_placement_info :system :transactions_jepsen_1 "gcp.jepsen-1.jepsen-1a" 3)
+        (yugabyte.auto/yb-admin test :create_transaction_table :transactions_jepsen_1)
+        (yugabyte.auto/yb-admin test :modify_table_placement_info :system :transactions_jepsen_2 "gcp.jepsen-2.jepsen-2a" 3)))
     )
 
   db/LogFiles

--- a/yugabyte/src/yugabyte/auto.clj
+++ b/yugabyte/src/yugabyte/auto.clj
@@ -459,7 +459,7 @@
             (ce-shared-opts node)
             :--master_addresses (master-addresses test)
             :--replication_factor (:replication-factor test)
-            :--auto_create_local_transaction_tables=false
+            ;:--auto_create_local_transaction_tables=false
             (master-tserver-experimental-tuning-flags test)
             (master-tserver-random-clock-skew test node)
             (master-tserver-wait-on-conflict-flags test)

--- a/yugabyte/src/yugabyte/auto.clj
+++ b/yugabyte/src/yugabyte/auto.clj
@@ -459,7 +459,7 @@
             (ce-shared-opts node)
             :--master_addresses (master-addresses test)
             :--replication_factor (:replication-factor test)
-            :--auto_create_local_transaction_tables=false
+            ;:--auto_create_local_transaction_tables=false
             (master-tserver-experimental-tuning-flags test)
             ;(master-tserver-random-clock-skew test node)
             (master-tserver-wait-on-conflict-flags test)

--- a/yugabyte/src/yugabyte/auto.clj
+++ b/yugabyte/src/yugabyte/auto.clj
@@ -459,6 +459,7 @@
             (ce-shared-opts node)
             :--master_addresses (master-addresses test)
             :--replication_factor (:replication-factor test)
+            :--auto_create_local_transaction_tables :false
             (master-tserver-experimental-tuning-flags test)
             ;(master-tserver-random-clock-skew test node)
             (master-tserver-wait-on-conflict-flags test)

--- a/yugabyte/src/yugabyte/auto.clj
+++ b/yugabyte/src/yugabyte/auto.clj
@@ -370,8 +370,7 @@
     (let [geo-ids (map #(+ 1 (mod % 2)) (range (count nodes)))
           geo-node-map (zipmap nodes geo-ids)
           node-id-int (get geo-node-map node)]
-      (info node)
-      (info [:--placement_cloud :ybc
+      (info node [:--placement_cloud :ybc
              :--placement_region (str "jepsen-" node-id-int)
              :--placement_zone (str "jepsen-" node-id-int "a")])
       [:--placement_cloud :ybc

--- a/yugabyte/src/yugabyte/auto.clj
+++ b/yugabyte/src/yugabyte/auto.clj
@@ -462,7 +462,7 @@
             (master-tserver-experimental-tuning-flags test)
             (master-tserver-random-clock-skew test node)
             (master-tserver-wait-on-conflict-flags test)
-            (master-tserver-geo-partitioning-flags test node (:nodes test))
+            ;(master-tserver-geo-partitioning-flags test node (:nodes test))
             (master-api-opts (:api test) node)
             )))
 
@@ -482,7 +482,7 @@
             (master-tserver-experimental-tuning-flags test)
             (master-tserver-random-clock-skew test node)
             (master-tserver-wait-on-conflict-flags test)
-            (master-tserver-geo-partitioning-flags test node (:nodes test))
+            ;(master-tserver-geo-partitioning-flags test node (:nodes test))
             (tserver-api-opts (:api test) node)
             (tserver-read-committed-flags test)
             (tserver-heartbeat-flags test)

--- a/yugabyte/src/yugabyte/auto.clj
+++ b/yugabyte/src/yugabyte/auto.clj
@@ -362,19 +362,15 @@
      :--enable_deadlock_detection]
     []))
 
-(defn get-random-node-geo
-  [count_nodes node_ip]
-  (+ 1 (rand-int count_nodes)))
-
-(def get-node-geo
-  (memoize get-random-node-geo))
-
 (defn master-tserver-geo-partitioning-flags
-  "Geo partitioning specific flags"
+  "Geo partitioning specific mapping flags
+  Each node will be mapped to id in [1 2] and then used in each node."
   [test node nodes]
   (if (clojure.string/includes? (name (:workload test)) "geo.")
-    (let [node-id-int (get-node-geo 2 (cn/ip node))]
-      [:--placement_cloud :gcp
+    (let [geo-ids (map #(+ 1 (mod % 2)) (range (count nodes)))
+          geo-node-map (zipmap nodes geo-ids)
+          node-id-int (get geo-node-map node)]
+      [:--placement_cloud :ybc
        :--placement_region (str "jepsen-" node-id-int)
        :--placement_zone (str "jepsen-" node-id-int "a")])
     []))

--- a/yugabyte/src/yugabyte/auto.clj
+++ b/yugabyte/src/yugabyte/auto.clj
@@ -477,6 +477,8 @@
             ce-tserver-bin
             (ce-shared-opts node)
             :--tserver_master_addrs (master-addresses test)
+
+            :--sql_log_statement :all
             ; Tracing
             :--enable_tracing
             :--rpc_slow_query_threshold_ms 1000

--- a/yugabyte/src/yugabyte/auto.clj
+++ b/yugabyte/src/yugabyte/auto.clj
@@ -517,10 +517,12 @@
     "Executed once on a first node in list (i.e. n1 by default) after per-node setup is done"
     (if (clojure.string/includes? (name (:workload test)) "geo.")
       (do
+        (info "Creating transactional table " :transactions_jepsen_1)
         (yugabyte.auto/yb-admin test :create_transaction_table :transactions_jepsen_1)
-        (yugabyte.auto/yb-admin test :modify_table_placement_info :system :transactions_jepsen_1 "gcp.jepsen-1.jepsen-1a" 2)
+        (yugabyte.auto/yb-admin test :modify_table_placement_info :system :transactions_jepsen_1 "ybc.jepsen-1.jepsen-1a" 2)
+        (info "Creating transactional table " :transactions_jepsen_2)
         (yugabyte.auto/yb-admin test :create_transaction_table :transactions_jepsen_2)
-        (yugabyte.auto/yb-admin test :modify_table_placement_info :system :transactions_jepsen_2 "gcp.jepsen-2.jepsen-2a" 2)))
+        (yugabyte.auto/yb-admin test :modify_table_placement_info :system :transactions_jepsen_2 "ybc.jepsen-2.jepsen-2a" 2)))
     )
 
   db/LogFiles

--- a/yugabyte/src/yugabyte/auto.clj
+++ b/yugabyte/src/yugabyte/auto.clj
@@ -199,13 +199,6 @@
     :ysql
     (ysql.client/check-setup-successful node))
 
-  (if (clojure.string/includes? (name (:workload test)) "geo.")
-    (do
-      (yugabyte.auto/yb-admin test :create_transaction_table :transactions_jepsen_1)
-      (yugabyte.auto/yb-admin test :modify_table_placement_info :system :transactions_jepsen_1 "gcp.jepsen-1.jepsen-1a" 3)
-      (yugabyte.auto/yb-admin test :create_transaction_table :transactions_jepsen_2)
-      (yugabyte.auto/yb-admin test :modify_table_placement_info :system :transactions_jepsen_2 "gcp.jepsen-2.jepsen-2a" 3)))
-
   :started)
 
 (defn stop! [db test node]

--- a/yugabyte/src/yugabyte/auto.clj
+++ b/yugabyte/src/yugabyte/auto.clj
@@ -459,7 +459,6 @@
             (ce-shared-opts node)
             :--master_addresses (master-addresses test)
             :--replication_factor (:replication-factor test)
-            :--ysql_log_statement :all
             (master-tserver-experimental-tuning-flags test)
             (master-tserver-random-clock-skew test node)
             (master-tserver-wait-on-conflict-flags test)
@@ -477,7 +476,6 @@
             ce-tserver-bin
             (ce-shared-opts node)
             :--tserver_master_addrs (master-addresses test)
-            :--ysql_log_statement :all
             ; Tracing
             :--enable_tracing
             :--rpc_slow_query_threshold_ms 1000
@@ -516,14 +514,14 @@
   db/Primary
   (setup-primary! [this test node]
     "Executed once on a first node in list (i.e. n1 by default) after per-node setup is done"
-    (if (clojure.string/includes? (name (:workload test)) "geo.")
-      (do
-        (info "Creating transactional table " :transactions_jepsen_1)
-        (yb-admin test :create_transaction_table :transactions_jepsen_1)
-        (yb-admin test :modify_table_placement_info :system :transactions_jepsen_1 "ybc.jepsen-1.jepsen-1a" 2)
-        (info "Creating transactional table " :transactions_jepsen_2)
-        (yb-admin test :create_transaction_table :transactions_jepsen_2)
-        (yb-admin test :modify_table_placement_info :system :transactions_jepsen_2 "ybc.jepsen-2.jepsen-2a" 2)))
+    ;(if (clojure.string/includes? (name (:workload test)) "geo.")
+    ;  (do
+    ;    (info "Creating transactional table " :transactions_jepsen_1)
+    ;    (yb-admin test :create_transaction_table :transactions_jepsen_1)
+    ;    (yb-admin test :modify_table_placement_info :system :transactions_jepsen_1 "ybc.jepsen-1.jepsen-1a" 2)
+    ;    (info "Creating transactional table " :transactions_jepsen_2)
+    ;    (yb-admin test :create_transaction_table :transactions_jepsen_2)
+    ;    (yb-admin test :modify_table_placement_info :system :transactions_jepsen_2 "ybc.jepsen-2.jepsen-2a" 2)))
     )
 
   db/LogFiles

--- a/yugabyte/src/yugabyte/auto.clj
+++ b/yugabyte/src/yugabyte/auto.clj
@@ -369,10 +369,11 @@
   (memoize get-random-node-geo))
 
 (defn master-tserver-geo-partitioning-flags
-  "Pessimistic specific flags"
+  "Geo partitioning specific flags"
   [test node nodes]
   (if (clojure.string/includes? (name (:workload test)) "geo.")
-    (let [node-id-int (get-node-geo (count nodes) (cn/ip node))]
+    ; todo in geo append test we using 3 zones
+    (let [node-id-int (get-node-geo 3 (cn/ip node))]
       [:--placement_cloud :gcp
        :--placement_region (str "jepsen-" node-id-int)
        :--placement_zone (str "jepsen-" node-id-int "a")])

--- a/yugabyte/src/yugabyte/auto.clj
+++ b/yugabyte/src/yugabyte/auto.clj
@@ -514,14 +514,14 @@
   db/Primary
   (setup-primary! [this test node]
     "Executed once on a first node in list (i.e. n1 by default) after per-node setup is done"
-    ;(if (clojure.string/includes? (name (:workload test)) "geo.")
-    ;  (do
-    ;    (info "Creating transactional table " :transactions_jepsen_1)
-    ;    (yb-admin test :create_transaction_table :transactions_jepsen_1)
-    ;    (yb-admin test :modify_table_placement_info :system :transactions_jepsen_1 "ybc.jepsen-1.jepsen-1a" 2)
-    ;    (info "Creating transactional table " :transactions_jepsen_2)
-    ;    (yb-admin test :create_transaction_table :transactions_jepsen_2)
-    ;    (yb-admin test :modify_table_placement_info :system :transactions_jepsen_2 "ybc.jepsen-2.jepsen-2a" 2)))
+    (if (clojure.string/includes? (name (:workload test)) "geo.")
+      (do
+        (info "Creating transactional table " :transactions_jepsen_1)
+        (yb-admin test :create_transaction_table :transactions_jepsen_1)
+        (yb-admin test :modify_table_placement_info :system :transactions_jepsen_1 "ybc.jepsen-1.jepsen-1a" 2)
+        (info "Creating transactional table " :transactions_jepsen_2)
+        (yb-admin test :create_transaction_table :transactions_jepsen_2)
+        (yb-admin test :modify_table_placement_info :system :transactions_jepsen_2 "ybc.jepsen-2.jepsen-2a" 2)))
     )
 
   db/LogFiles

--- a/yugabyte/src/yugabyte/auto.clj
+++ b/yugabyte/src/yugabyte/auto.clj
@@ -198,6 +198,14 @@
 
     :ysql
     (ysql.client/check-setup-successful node))
+
+  (if (clojure.string/includes? (name (:workload test)) "geo.")
+    (do
+      (yugabyte.auto/yb-admin test :create_transaction_table :jepsen_1_transactions)
+      (yugabyte.auto/yb-admin test :modify_table_placement_info :system :jepsen_1_transactions "gcp.jepsen-1.jepsen-1a" 3)
+      (yugabyte.auto/yb-admin test :create_transaction_table :jepsen_2_transactions)
+      (yugabyte.auto/yb-admin test :modify_table_placement_info :system :jepsen_2_transactions "gcp.jepsen-2.jepsen-2a" 3)))
+
   :started)
 
 (defn stop! [db test node]

--- a/yugabyte/src/yugabyte/auto.clj
+++ b/yugabyte/src/yugabyte/auto.clj
@@ -459,7 +459,7 @@
             (ce-shared-opts node)
             :--master_addresses (master-addresses test)
             :--replication_factor (:replication-factor test)
-            ;:--auto_create_local_transaction_tables=false
+            :--auto_create_local_transaction_tables=false
             (master-tserver-experimental-tuning-flags test)
             ;(master-tserver-random-clock-skew test node)
             (master-tserver-wait-on-conflict-flags test)

--- a/yugabyte/src/yugabyte/auto.clj
+++ b/yugabyte/src/yugabyte/auto.clj
@@ -370,6 +370,10 @@
     (let [geo-ids (map #(+ 1 (mod % 2)) (range (count nodes)))
           geo-node-map (zipmap nodes geo-ids)
           node-id-int (get geo-node-map node)]
+      (info node)
+      (info [:--placement_cloud :ybc
+             :--placement_region (str "jepsen-" node-id-int)
+             :--placement_zone (str "jepsen-" node-id-int "a")])
       [:--placement_cloud :ybc
        :--placement_region (str "jepsen-" node-id-int)
        :--placement_zone (str "jepsen-" node-id-int "a")])

--- a/yugabyte/src/yugabyte/auto.clj
+++ b/yugabyte/src/yugabyte/auto.clj
@@ -367,9 +367,10 @@
   "Pessimistic specific flags"
   [test]
   (if (clojure.string/includes? (name (:workload test)) "geo.")
-    [:--placement_cloud :gcp
-     :--placement_region (str "jepsen-" (swap! node-id inc))
-     :--placement_zone (str "jepsen-" (swap! node-id inc) "a")]
+    (let [node-id-int (swap! node-id inc)]
+      [:--placement_cloud :gcp
+       :--placement_region (str "jepsen-" node-id-int)
+       :--placement_zone (str "jepsen-" node-id-int "a")])
     []))
 
 

--- a/yugabyte/src/yugabyte/auto.clj
+++ b/yugabyte/src/yugabyte/auto.clj
@@ -519,7 +519,7 @@
       (do
         (yugabyte.auto/yb-admin test :create_transaction_table :transactions_jepsen_1)
         (yugabyte.auto/yb-admin test :modify_table_placement_info :system :transactions_jepsen_1 "gcp.jepsen-1.jepsen-1a" 3)
-        (yugabyte.auto/yb-admin test :create_transaction_table :transactions_jepsen_1)
+        (yugabyte.auto/yb-admin test :create_transaction_table :transactions_jepsen_2)
         (yugabyte.auto/yb-admin test :modify_table_placement_info :system :transactions_jepsen_2 "gcp.jepsen-2.jepsen-2a" 3)))
     )
 

--- a/yugabyte/src/yugabyte/bank.clj
+++ b/yugabyte/src/yugabyte/bank.clj
@@ -1,8 +1,7 @@
 (ns yugabyte.bank
   "Simulates transfers between bank accounts"
   (:refer-clojure :exclude [test])
-  (:require [clojure.tools.logging :refer [debug info warn]]
-            [jepsen.tests.bank :as bank]
+  (:require [jepsen.tests.bank :as bank]
             [yugabyte.generator :as ygen]))
 
 (defn workload

--- a/yugabyte/src/yugabyte/core.clj
+++ b/yugabyte/src/yugabyte/core.clj
@@ -2,12 +2,9 @@
   "Integrates workloads, nemeses, and automation to construct test maps."
   (:require [clojure.tools.logging :refer :all]
             [clojure.string :as str]
-            [clojure.pprint :refer [pprint]]
             [jepsen.checker :as checker]
-            [jepsen.client :as client]
             [jepsen.generator :as gen]
             [jepsen.tests :as tests]
-            [jepsen.control.util :as cu]
             [jepsen.os.debian :as debian]
             [jepsen.os.centos :as centos]
             [yugabyte [append :as append]

--- a/yugabyte/src/yugabyte/core.clj
+++ b/yugabyte/src/yugabyte/core.clj
@@ -11,7 +11,7 @@
             [jepsen.os.debian :as debian]
             [jepsen.os.centos :as centos]
             [yugabyte [append :as append]
-                      [default-value :as default-value]]
+             [default-value :as default-value]]
             [yugabyte.auto :as auto]
             [yugabyte.bank :as bank]
             [yugabyte.bank-improved :as bank-improved]
@@ -30,8 +30,8 @@
             [yugabyte.ycql.set]
             [yugabyte.ycql.single-key-acid]
             [yugabyte.ysql [append :as ysql.append]
-                           [append-table :as ysql.append-table]
-                           [default-value :as ysql.default-value]]
+             [append-table :as ysql.append-table]
+             [default-value :as ysql.default-value]]
             [yugabyte.ysql.bank]
             [yugabyte.ysql.bank-improved]
             [yugabyte.ysql.counter]
@@ -104,16 +104,22 @@
          :sz.long-fork       (with-client long-fork/workload (yugabyte.ysql.long-fork/->YSQLLongForkClient))
          :sz.single-key-acid (with-client single-key-acid/workload (yugabyte.ysql.single-key-acid/->YSQLSingleKeyAcidClient))
          :sz.multi-key-acid  (with-client multi-key-acid/workload (yugabyte.ysql.multi-key-acid/->YSQLMultiKeyAcidClient))
-         :sz.ol.append          (with-client append/workload-serializable (ysql.append/->Client :serializable :optimistic))
-         :sz.pl.append          (with-client append/workload-serializable (ysql.append/->Client :serializable :pessimistic))
+         :sz.ol.geo.append   (with-client append/workload-serializable (ysql.append/->Client :serializable :optimistic :geo))
+         :sz.pl.geo.append   (with-client append/workload-serializable (ysql.append/->Client :serializable :pessimistic :geo))
+         :sz.ol.append       (with-client append/workload-serializable (ysql.append/->Client :serializable :optimistic :no-geo))
+         :sz.pl.append       (with-client append/workload-serializable (ysql.append/->Client :serializable :pessimistic :no-geo))
          :sz.append-table    (with-client append/workload-serializable (ysql.append-table/->Client :serializable))
          :sz.default-value   (with-client default-value/workload (ysql.default-value/->Client))
-         :rc.ol.append          (with-client append/workload-rc (ysql.append/->Client :read-committed :optimistic))
-         :rc.pl.append          (with-client append/workload-rc (ysql.append/->Client :read-committed :pessimistic))
+         :rc.ol.geo.append   (with-client append/workload-rc (ysql.append/->Client :read-committed :optimistic :geo))
+         :rc.pl.geo.append   (with-client append/workload-rc (ysql.append/->Client :read-committed :pessimistic :geo))
+         :rc.ol.append       (with-client append/workload-rc (ysql.append/->Client :read-committed :optimistic :no-geo))
+         :rc.pl.append       (with-client append/workload-rc (ysql.append/->Client :read-committed :pessimistic :no-geo))
          ; See https://docs.yugabyte.com/latest/architecture/transactions/isolation-levels/
          ; :snapshot-isolation maps to :repeatable_read SQL
-         :si.ol.append          (with-client append/workload-si (ysql.append/->Client :repeatable-read :optimistic))
-         :si.pl.append          (with-client append/workload-si (ysql.append/->Client :repeatable-read :pessimistic))
+         :si.ol.geo.append   (with-client append/workload-si (ysql.append/->Client :repeatable-read :optimistic :geo))
+         :si.pl.geo.append   (with-client append/workload-si (ysql.append/->Client :repeatable-read :pessimistic :geo))
+         :si.ol.append       (with-client append/workload-si (ysql.append/->Client :repeatable-read :optimistic :no-geo))
+         :si.pl.append       (with-client append/workload-si (ysql.append/->Client :repeatable-read :pessimistic :no-geo))
          :si.bank            (with-client bank/workload-allow-neg (yugabyte.ysql.bank/->YSQLBankClient true :repeatable-read))
          :si.bank-multitable (with-client bank/workload-allow-neg (yugabyte.ysql.bank/->YSQLBankClient true :repeatable-read))
          :si.bank-contention (with-client bank-improved/workload-contention-keys (yugabyte.ysql.bank-improved/->YSQLBankContentionClient :repeatable-read))})
@@ -221,7 +227,7 @@
   "Initial test construction from a map of CLI options. Establishes the test
   name, OS, DB."
   [opts]
-  (let [api         (keyword (namespace (:workload opts)))
+  (let [api (keyword (namespace (:workload opts)))
         url-version (first (re-find version-regex (get opts :url "")))]
     (assoc opts
       :version (or url-version (:version opts))
@@ -248,50 +254,50 @@
   finalizes the test."
   [opts]
   (let [workload ((get workloads (:workload opts)) opts)
-        nemesis  (nemesis/nemesis opts)
-        gen      (->> (:generator workload)
-                      (gen/nemesis (:generator nemesis))
-                      (gen/time-limit (:time-limit opts)))
-        gen      (if (:final-generator workload)
-                   (gen/phases gen
-                               (gen/log "Healing cluster")
-                               (gen/nemesis (:final-generator nemesis))
-                               (gen/log "Waiting for recovery...")
-                               (gen/sleep (:final-recovery-time opts))
-                               (gen/clients (:final-generator workload)))
-                   gen)
-        perf     (checker/perf
-                   {:nemeses #{{:name       "kill master"
-                                :start      #{:kill-master :stop-master}
-                                :stop       #{:start-master}
-                                :fill-color "#E9A4A0"}
-                               {:name       "kill tserver"
-                                :start      #{:kill-tserver :stop-tserver}
-                                :stop       #{:start-tserver}
-                                :fill-color "#E9C3A0"}
-                               {:name       "pause master"
-                                :start      #{:pause-master}
-                                :stop       #{:resume-master}
-                                :fill-color "#A0B1E9"}
-                               {:name       "pause tserver"
-                                :start      #{:pause-tserver}
-                                :stop       #{:resume-tserver}
-                                :fill-color "#B8A0E9"}
-                               {:name       "clock skew"
-                                :start      #{:bump-clock :strobe-clock}
-                                :stop       #{:reset-clock}
-                                :fill-color "#D2E9A0"}
-                               {:name       "partition"
-                                :start      #{:start-partition}
-                                :stop       #{:stop-partition}
-                                :fill-color "#888888"}}})
-        checker  (if (is-stub-workload (:workload opts))
-                   (:checker workload)
-                   (checker/compose {:perf                 perf
-                                     :stats                (checker/stats)
-                                     :unhandled-exceptions (checker/unhandled-exceptions)
-                                     :clock                (checker/clock-plot)
-                                     :workload             (:checker workload)}))]
+        nemesis (nemesis/nemesis opts)
+        gen (->> (:generator workload)
+                 (gen/nemesis (:generator nemesis))
+                 (gen/time-limit (:time-limit opts)))
+        gen (if (:final-generator workload)
+              (gen/phases gen
+                          (gen/log "Healing cluster")
+                          (gen/nemesis (:final-generator nemesis))
+                          (gen/log "Waiting for recovery...")
+                          (gen/sleep (:final-recovery-time opts))
+                          (gen/clients (:final-generator workload)))
+              gen)
+        perf (checker/perf
+               {:nemeses #{{:name       "kill master"
+                            :start      #{:kill-master :stop-master}
+                            :stop       #{:start-master}
+                            :fill-color "#E9A4A0"}
+                           {:name       "kill tserver"
+                            :start      #{:kill-tserver :stop-tserver}
+                            :stop       #{:start-tserver}
+                            :fill-color "#E9C3A0"}
+                           {:name       "pause master"
+                            :start      #{:pause-master}
+                            :stop       #{:resume-master}
+                            :fill-color "#A0B1E9"}
+                           {:name       "pause tserver"
+                            :start      #{:pause-tserver}
+                            :stop       #{:resume-tserver}
+                            :fill-color "#B8A0E9"}
+                           {:name       "clock skew"
+                            :start      #{:bump-clock :strobe-clock}
+                            :stop       #{:reset-clock}
+                            :fill-color "#D2E9A0"}
+                           {:name       "partition"
+                            :start      #{:start-partition}
+                            :stop       #{:stop-partition}
+                            :fill-color "#888888"}}})
+        checker (if (is-stub-workload (:workload opts))
+                  (:checker workload)
+                  (checker/compose {:perf                 perf
+                                    :stats                (checker/stats)
+                                    :unhandled-exceptions (checker/unhandled-exceptions)
+                                    :clock                (checker/clock-plot)
+                                    :workload             (:checker workload)}))]
     (merge tests/noop-test
            opts
            (dissoc workload

--- a/yugabyte/src/yugabyte/counter.clj
+++ b/yugabyte/src/yugabyte/counter.clj
@@ -1,6 +1,5 @@
 (ns yugabyte.counter
-  (:require [clojure.tools.logging :refer [debug info warn]]
-            [jepsen.checker :as checker]
+  (:require [jepsen.checker :as checker]
             [jepsen.generator :as gen]
             [jepsen.checker.timeline :as timeline]
             [yugabyte.generator :as ygen]))

--- a/yugabyte/src/yugabyte/long_fork.clj
+++ b/yugabyte/src/yugabyte/long_fork.clj
@@ -2,9 +2,7 @@
   "Looks for instances of long fork: a snapshot isolation violation involving
   incompatible orders of writes to disparate objects"
   (:refer-clojure :exclude [test])
-  (:require [clojure [pprint :refer [pprint]]]
-            [clojure.tools.logging :refer [info]]
-            [jepsen.tests.long-fork :as lf]
+  (:require [jepsen.tests.long-fork :as lf]
             [yugabyte.generator :as ygen]))
 
 (defn workload

--- a/yugabyte/src/yugabyte/nemesis.clj
+++ b/yugabyte/src/yugabyte/nemesis.clj
@@ -1,12 +1,10 @@
 (ns yugabyte.nemesis
   (:require [clojure.tools.logging :refer :all]
-            [clojure.pprint :refer [pprint]]
             [jepsen.control :as c]
             [jepsen.generator :as gen]
             [jepsen.nemesis :as nemesis]
             [jepsen.util :as util :refer [meh timeout]]
             [jepsen.nemesis.time :as nt]
-            [slingshot.slingshot :refer [try+]]
             [yugabyte.auto :as auto]))
 
 (defn process-nemesis

--- a/yugabyte/src/yugabyte/set.clj
+++ b/yugabyte/src/yugabyte/set.clj
@@ -1,8 +1,6 @@
 (ns yugabyte.set
   "Adds elements to sets and reads them back"
-  (:require [clojure.pprint :refer [pprint]]
-            [clojure.tools.logging :refer [info]]
-            [jepsen.generator :as gen]
+  (:require [jepsen.generator :as gen]
             [jepsen.checker :as checker]
             [yugabyte.generator :as ygen]))
 

--- a/yugabyte/src/yugabyte/ycql/client.clj
+++ b/yugabyte/src/yugabyte/ycql/client.clj
@@ -5,12 +5,10 @@
                                      [policies :as policies]
                                      [cql :as cql]]
             [clojure.tools.logging :refer [info]]
-            [clojure.pprint :refer [pprint]]
             [jepsen [util :as util]]
             [jepsen.control.net :as cn]
             [dom-top.core :as dt]
-            [wall.hack :as wh]
-            [slingshot.slingshot :refer [try+ throw+]])
+            [wall.hack :as wh])
   (:import (java.net InetSocketAddress)
            (com.datastax.driver.core Cluster
                                      Cluster$Builder

--- a/yugabyte/src/yugabyte/ycql/long_fork.clj
+++ b/yugabyte/src/yugabyte/ycql/long_fork.clj
@@ -1,8 +1,6 @@
 (ns yugabyte.ycql.long-fork
   (:refer-clojure :exclude [test])
-  (:require [clojure [pprint :refer [pprint]]]
-            [clojure.tools.logging :refer [info]]
-            [clojurewerkz.cassaforte.cql :as cql]
+  (:require [clojurewerkz.cassaforte.cql :as cql]
             [clojurewerkz.cassaforte.query :as q]
             [jepsen.tests.long-fork :as lf]
             [yugabyte.ycql.client :as c]))

--- a/yugabyte/src/yugabyte/ycql/multi_key_acid.clj
+++ b/yugabyte/src/yugabyte/ycql/multi_key_acid.clj
@@ -1,6 +1,5 @@
 (ns yugabyte.ycql.multi-key-acid
-  (:require [clojure.tools.logging :refer [debug info warn]]
-            [jepsen.independent :as independent]
+  (:require [jepsen.independent :as independent]
             [jepsen.txn.micro-op :as mop]
             [clojurewerkz.cassaforte.client :as cassandra]
             [clojurewerkz.cassaforte.query :as q :refer :all]

--- a/yugabyte/src/yugabyte/ycql/set.clj
+++ b/yugabyte/src/yugabyte/ycql/set.clj
@@ -1,7 +1,5 @@
 (ns yugabyte.ycql.set
-  (:require [clojure.pprint :refer [pprint]]
-            [clojure.tools.logging :refer [info]]
-            [clojurewerkz.cassaforte.query :as q]
+  (:require [clojurewerkz.cassaforte.query :as q]
             [clojurewerkz.cassaforte.cql :as cql]
             [yugabyte.ycql.client :as c]))
 

--- a/yugabyte/src/yugabyte/ycql/single_key_acid.clj
+++ b/yugabyte/src/yugabyte/ycql/single_key_acid.clj
@@ -1,9 +1,6 @@
 (ns yugabyte.ycql.single-key-acid
   (:require [clojure [pprint :refer :all]]
-            [clojure.tools.logging :refer [debug info warn]]
             [jepsen.independent :as independent]
-            [knossos.model :as model]
-            [clojurewerkz.cassaforte.client :as cassandra]
             [clojurewerkz.cassaforte.query :refer :all]
             [clojurewerkz.cassaforte.policies :refer :all]
             [clojurewerkz.cassaforte.cql :as cql]

--- a/yugabyte/src/yugabyte/ysql/append.clj
+++ b/yugabyte/src/yugabyte/ysql/append.clj
@@ -70,7 +70,6 @@
   (let [r (c/execute! conn [(str "update " table
                                  " set " col " = CONCAT(" col ", ',', ?) "
                                  "where k = ?") v row])]
-    (info geo-partitioning conn table row col v)
     (when (= [0] r)
       ; No rows updated
       (c/execute! conn
@@ -112,7 +111,6 @@
   (let [table (table-for test k)
         row (row-for test k)
         col (col-for test k)]
-    (info geo-partitioning locking conn test [f k v])
     [f k (case f
            :r
            (read-primary locking conn table row col)
@@ -194,6 +192,7 @@
                                    :table-spec   (str "PARTITION BY LIST (geo_partition)")}))
                   (if (= geo-partitioning :geo)
                     (do
+                      (info "Create table partitions for " table)
                       (c/execute! c (str "CREATE TABLE " table "_1a"
                                          "PARTITION OF " table " (k, k2, geo_partition) "
                                          "PRIMARY KEY (k) FOR VALUES IN ('1a') "

--- a/yugabyte/src/yugabyte/ysql/append.clj
+++ b/yugabyte/src/yugabyte/ysql/append.clj
@@ -195,9 +195,9 @@
   (info (str "Create table partitions for " table "_" postfix " for '" postfix "'"))
   (c/execute! c (str "CREATE TABLE " table "_" postfix " "
                      "PARTITION OF " table " (k, k2, geo_partition"
-                     ", PRIMARY KEY (k, geo_partition)) FOR VALUES IN ('" postfix "') "
-                     ;") FOR VALUES IN ('" postfix "') "
-                     ;"TABLESPACE " tablespace-name "_" postfix
+                     ;", PRIMARY KEY (k, geo_partition)) FOR VALUES IN ('" postfix "') "
+                     ") FOR VALUES IN ('" postfix "') "
+                     "TABLESPACE " tablespace-name "_" postfix
                      )))
 
 (defrecord InternalClient [isolation locking geo-partitioning]

--- a/yugabyte/src/yugabyte/ysql/append.clj
+++ b/yugabyte/src/yugabyte/ysql/append.clj
@@ -125,16 +125,20 @@
       {
        :num_replicas     3
        :placement_blocks [
-                          {:cloud             :ybc
+                          {
+                           :cloud             :ybc
                            :region            :jepsen-1
                            :zone              :jepsen-1a
                            :min_num_replicas  1
-                           :leader_preference 1}
-                          {:cloud             :ybc
+                           :leader_preference 1
+                           }
+                          {
+                           :cloud             :ybc
                            :region            :jepsen-2
                            :zone              :jepsen-2a
                            :min_num_replicas  1
-                           :leader_preference 2},
+                           :leader_preference 2
+                           }
                           ]
        })))
 

--- a/yugabyte/src/yugabyte/ysql/append.clj
+++ b/yugabyte/src/yugabyte/ysql/append.clj
@@ -111,14 +111,15 @@
 (defn setup-geo-partition
   [conn geo-partitioning]
   (if (= geo-partitioning :geo)
-    (c/execute! conn [("CREATE TABLESPACE geo_tablespace
+    (c/execute! conn ["CREATE TABLESPACE geo_tablespace
     WITH (replica_placement='{\"num_replicas\": 3,
     \"placement_blocks\": [
     {\"cloud\":\"gcp\",\"region\":\"jepsen-1\",\"zone\":\"jepsen-1a\",\"min_num_replicas\":1,\"leader_preference\":1},
     {\"cloud\":\"gcp\",\"region\":\"jepsen-2\",\"zone\":\"jepsen-2a\",\"min_num_replicas\":1,\"leader_preference\":2},
-    {\"cloud\":\"gcp\",\"region\":\"jepsen-3\",\"zone\":\"jepsen-3a\",\"min_num_replicas\":1}]}');")])))
+    {\"cloud\":\"gcp\",\"region\":\"jepsen-3\",\"zone\":\"jepsen-3a\",\"min_num_replicas\":1}]}');"])))
 
 (defn geo-table-clause
+  [geo-partitioning]
   (if (= geo-partitioning :geo)
     ("TABLESPACE geo_tablespace")
     ("")))

--- a/yugabyte/src/yugabyte/ysql/append.clj
+++ b/yugabyte/src/yugabyte/ysql/append.clj
@@ -84,9 +84,7 @@
         (c/execute! conn
                     [(str "insert into " table
                           " (k, k2, " col ")"
-                          " values (?, ?, ?)") row row v]))
-    )
-    v))
+                          " values (?, ?, ?)") row row v]))) v))
 
 (defn read-secondary
   "Reads a key based on a predicate over a secondary key, k2"
@@ -119,8 +117,8 @@
   micro-op."
   [geo-partitioning locking conn test [f k v]]
   (let [table (table-for test k)
-        row   (row-for test k)
-        col   (col-for test k)]
+        row (row-for test k)
+        col (col-for test k)]
     [f k (case f
            :r
            (read-primary locking conn table row col)
@@ -228,12 +226,12 @@
            dorun)))
 
   (invoke-op! [this test op c conn-wrapper]
-    (let [txn      (:value op)
+    (let [txn (:value op)
           use-txn? (< 1 (count txn))
-          txn'     (if use-txn?
-                     (j/with-db-transaction [c c {:isolation isolation}]
-                                            (mapv (partial mop! geo-partitioning locking c test) txn))
-                     (mapv (partial mop! geo-partitioning locking c test) txn))]
+          txn' (if use-txn?
+                 (j/with-db-transaction [c c {:isolation isolation}]
+                                        (mapv (partial mop! geo-partitioning locking c test) txn))
+                 (mapv (partial mop! geo-partitioning locking c test) txn))]
       (assoc op :type :ok, :value txn'))))
 
 (c/defclient Client InternalClient)

--- a/yugabyte/src/yugabyte/ysql/append.clj
+++ b/yugabyte/src/yugabyte/ysql/append.clj
@@ -130,6 +130,12 @@
 
   (setup-cluster! [this test c conn-wrapper]
     (setup-geo-partition c geo-partitioning)
+    (if (clojure.string/includes? (name (:workload test)) "geo.")
+      (do
+        (yugabyte.auto/yb-admin test :create_transaction_table :transactions_jepsen_1)
+        (yugabyte.auto/yb-admin test :modify_table_placement_info :system :transactions_jepsen_1 "gcp.jepsen-1.jepsen-1a" 3)
+        (yugabyte.auto/yb-admin test :create_transaction_table :transactions_jepsen_1)
+        (yugabyte.auto/yb-admin test :modify_table_placement_info :system :transactions_jepsen_2 "gcp.jepsen-2.jepsen-2a" 3)))
     (->> (range (table-count test))
          (map table-name)
          (map (fn [table]

--- a/yugabyte/src/yugabyte/ysql/append.clj
+++ b/yugabyte/src/yugabyte/ysql/append.clj
@@ -155,7 +155,7 @@
                              :region            :jepsen-2
                              :zone              :jepsen-2a
                              :min_num_replicas  1
-                             :leader_preference 2
+                             :leader_preference 1
                              }
                             ]
          }))))

--- a/yugabyte/src/yugabyte/ysql/append.clj
+++ b/yugabyte/src/yugabyte/ysql/append.clj
@@ -77,14 +77,15 @@
                                  "where k = ?") v row])]
     (when (= [0] r)
       ; No rows updated
-      (if (= geo-partitioning :geo)
-        (if (mod v 2)
-          (insert-primary-geo conn table geo-partitioning col row v "1a")
-          (insert-primary-geo conn table geo-partitioning col row v "2a"))
+      ;(if (= geo-partitioning :geo)
+      ;  (if (mod v 2)
+      ;    (insert-primary-geo conn table geo-partitioning col row v "1a")
+      ;    (insert-primary-geo conn table geo-partitioning col row v "2a"))
         (c/execute! conn
                     [(str "insert into " table
                           " (k, k2, " col (get-geo-insert-column geo-partitioning) ")"
-                          " values (?, ?, ?)") row row v])))
+                          " values (?, ?, ?)") row row v]))
+    ;)
     v))
 
 (defn read-secondary
@@ -176,7 +177,8 @@
   (if (= geo-partitioning :geo)
     [[:k :int]
      [:k2 :int]
-     [:geo_partition :varchar]]
+     ;[:geo_partition :varchar]
+     ]
     [;[:k :int "unique"]
      [:k :int "PRIMARY KEY"]
      [:k2 :int]]))

--- a/yugabyte/src/yugabyte/ysql/append.clj
+++ b/yugabyte/src/yugabyte/ysql/append.clj
@@ -163,12 +163,18 @@
 (defn get-create-table-columns-clause
   [geo-partitioning]
   (if (= geo-partitioning :geo)
-    [[:k :int "PRIMARY KEY"]
+    [[:k :int]
      [:k2 :int]
-     [:geo_partition :varchar "PRIMARY KEY"]]
+     [:geo_partition :varchar]]
     [;[:k :int "unique"]
      [:k :int "PRIMARY KEY"]
      [:k2 :int]]))
+
+(defn get-table-spec
+  [geo-partitioning]
+  (if (= geo-partitioning :geo)
+    "PARTITION BY LIST (geo_partition)"
+    ""))
 
 (defrecord InternalClient [isolation locking geo-partitioning]
   c/YSQLYbClient
@@ -189,7 +195,7 @@
                                     (map (fn [i] [(col-for test i) :text])
                                          (range keys-per-row)))
                                   {:conditional? true
-                                   :table-spec   (str "PARTITION BY LIST (geo_partition)")}))
+                                   :table-spec   (get-table-spec geo-partitioning)}))
                   (if (= geo-partitioning :geo)
                     (do
                       (info "Create table partitions for " table)

--- a/yugabyte/src/yugabyte/ysql/append.clj
+++ b/yugabyte/src/yugabyte/ysql/append.clj
@@ -199,8 +199,7 @@
   (c/execute! c (str "CREATE TABLE " table "_" postfix " "
                      "PARTITION OF " table " (k, k2, geo_partition"
                      ", PRIMARY KEY (k, geo_partition)) FOR VALUES IN ('" postfix "') "
-                     "TABLESPACE " tablespace-name "_" postfix
-                     )))
+                     "TABLESPACE " tablespace-name "_" postfix)))
 
 (defrecord InternalClient [isolation locking geo-partitioning]
   c/YSQLYbClient

--- a/yugabyte/src/yugabyte/ysql/append.clj
+++ b/yugabyte/src/yugabyte/ysql/append.clj
@@ -178,7 +178,7 @@
     [[:k :int]
      [:k2 :int]
      [:geo_partition :varchar]
-     "PRIMARY KEY (k, geo_partition)"]
+     ["PRIMARY KEY (k, geo_partition)"] ]
     [;[:k :int "unique"]
      [:k :int "PRIMARY KEY"]
      [:k2 :int]]))

--- a/yugabyte/src/yugabyte/ysql/append.clj
+++ b/yugabyte/src/yugabyte/ysql/append.clj
@@ -37,6 +37,12 @@
   [test k]
   (str "v" (mod k keys-per-row)))
 
+(defn get-geo-insert-column
+  [geo-partitioning v]
+  (if (= geo-partitioning :geo)
+    (str ", geo_partition"))
+    ""))
+
 (defn get-geo-insert-row
   [geo-partitioning v]
   (if (= geo-partitioning :geo)

--- a/yugabyte/src/yugabyte/ysql/append.clj
+++ b/yugabyte/src/yugabyte/ysql/append.clj
@@ -116,8 +116,7 @@
                 WITH (replica_placement='{\"num_replicas\": 3,
                 \"placement_blocks\": [
                 {\"cloud\":\"gcp\",\"region\":\"jepsen-1\",\"zone\":\"jepsen-1a\",\"min_num_replicas\":1,\"leader_preference\":1},
-                {\"cloud\":\"gcp\",\"region\":\"jepsen-2\",\"zone\":\"jepsen-2a\",\"min_num_replicas\":1,\"leader_preference\":2},
-                {\"cloud\":\"gcp\",\"region\":\"jepsen-3\",\"zone\":\"jepsen-3a\",\"min_num_replicas\":1}]}');"]
+                {\"cloud\":\"gcp\",\"region\":\"jepsen-2\",\"zone\":\"jepsen-2a\",\"min_num_replicas\":1,\"leader_preference\":2}]}');"]
                 {:transaction? false})))
 
 (defn geo-table-clause

--- a/yugabyte/src/yugabyte/ysql/append.clj
+++ b/yugabyte/src/yugabyte/ysql/append.clj
@@ -176,7 +176,7 @@
     [[:k :int]
      [:k2 :int]
      [:geo_partition :varchar]
-     ["PRIMARY KEY (k, geo_partition)"]
+     ;["PRIMARY KEY (k, geo_partition)"]
      ]
     [;[:k :int "unique"]
      [:k :int "PRIMARY KEY"]
@@ -193,8 +193,8 @@
   (info (str "Create table partitions for " table "_" postfix " for '" postfix "'"))
   (c/execute! c (str "CREATE TABLE " table "_" postfix " "
                      "PARTITION OF " table " (k, k2, geo_partition"
-                     ;", PRIMARY KEY (k, geo_partition)) FOR VALUES IN ('" postfix "') "
-                     ") FOR VALUES IN ('" postfix "') "
+                     ", PRIMARY KEY (k, geo_partition)) FOR VALUES IN ('" postfix "') "
+                     ;") FOR VALUES IN ('" postfix "') "
                      ;"TABLESPACE " tablespace-name "_" postfix
                      )))
 

--- a/yugabyte/src/yugabyte/ysql/append.clj
+++ b/yugabyte/src/yugabyte/ysql/append.clj
@@ -186,7 +186,6 @@
 (defn get-table-spec
   [geo-partitioning]
   (if (= geo-partitioning :geo)
-    ""
     "PARTITION BY LIST (geo_partition)"
     ""))
 

--- a/yugabyte/src/yugabyte/ysql/append.clj
+++ b/yugabyte/src/yugabyte/ysql/append.clj
@@ -195,11 +195,11 @@
                       (info "Create table partitions for " table)
                       (c/execute! c (str "CREATE TABLE " table "_1a"
                                          "PARTITION OF " table " (k, k2, geo_partition) "
-                                         "PRIMARY KEY (k) FOR VALUES IN ('1a') "
+                                         "PRIMARY KEY (k, geo_partition) FOR VALUES IN ('1a') "
                                          "TABLESPACE (" tablespace-name "_1a)"))
                       (c/execute! c (str "CREATE TABLE " table "_2a"
                                          "PARTITION OF " table " (k, k2, geo_partition) "
-                                         "PRIMARY KEY (k) FOR VALUES IN ('2a') "
+                                         "PRIMARY KEY (k, geo_partition) FOR VALUES IN ('2a') "
                                          "TABLESPACE (" tablespace-name "_2a)"))))))
            dorun)))
 

--- a/yugabyte/src/yugabyte/ysql/append.clj
+++ b/yugabyte/src/yugabyte/ysql/append.clj
@@ -195,7 +195,7 @@
   (c/execute! c (str "CREATE TABLE " table "_" postfix " "
                      "PARTITION OF " table " (k, k2, geo_partition"
                      ", PRIMARY KEY (k, geo_partition)) FOR VALUES IN ('" postfix "') "
-                     ;"TABLESPACE " tablespace-name "_" postfix
+                     "TABLESPACE " tablespace-name "_" postfix
                      )))
 
 (defrecord InternalClient [isolation locking geo-partitioning]

--- a/yugabyte/src/yugabyte/ysql/append.clj
+++ b/yugabyte/src/yugabyte/ysql/append.clj
@@ -175,7 +175,7 @@
 (defn get-create-table-columns-clause
   [geo-partitioning]
   (if (= geo-partitioning :geo)
-    [[:k :int]
+    [[:k :int "PRIMARY KEY"]
      [:k2 :int]
      ;[:geo_partition :varchar]
      ]

--- a/yugabyte/src/yugabyte/ysql/append.clj
+++ b/yugabyte/src/yugabyte/ysql/append.clj
@@ -200,12 +200,12 @@
                     (do
                       (info "Create table partitions for " table)
                       (c/execute! c (str "CREATE TABLE " table "_1a"
-                                         "PARTITION OF " table " (k, k2, geo_partition) "
-                                         "PRIMARY KEY (k, geo_partition) FOR VALUES IN ('1a') "
+                                         "PARTITION OF " table " (k, k2, geo_partition, "
+                                         "PRIMARY KEY (k, geo_partition)) FOR VALUES IN ('1a') "
                                          "TABLESPACE (" tablespace-name "_1a)"))
                       (c/execute! c (str "CREATE TABLE " table "_2a"
-                                         "PARTITION OF " table " (k, k2, geo_partition) "
-                                         "PRIMARY KEY (k, geo_partition) FOR VALUES IN ('2a') "
+                                         "PARTITION OF " table " (k, k2, geo_partition, "
+                                         "PRIMARY KEY (k, geo_partition)) FOR VALUES IN ('2a') "
                                          "TABLESPACE (" tablespace-name "_2a)"))))))
            dorun)))
 

--- a/yugabyte/src/yugabyte/ysql/append.clj
+++ b/yugabyte/src/yugabyte/ysql/append.clj
@@ -178,7 +178,7 @@
     [[:k :int]
      [:k2 :int]
      [:geo_partition :varchar]
-     ;["PRIMARY KEY (k, geo_partition)"]
+     ["PRIMARY KEY (k, geo_partition)"]
      ]
     [;[:k :int "unique"]
      [:k :int "PRIMARY KEY"]

--- a/yugabyte/src/yugabyte/ysql/append.clj
+++ b/yugabyte/src/yugabyte/ysql/append.clj
@@ -142,7 +142,7 @@
         conn
         (str tablespace-name "_1a")
         {
-         :num_replicas     3
+         :num_replicas     2
          :placement_blocks [
                             {
                              :cloud             :ybc
@@ -157,7 +157,7 @@
         conn
         (str tablespace-name "_2a")
         {
-         :num_replicas     3
+         :num_replicas     2
          :placement_blocks [
                             {
                              :cloud             :ybc

--- a/yugabyte/src/yugabyte/ysql/append.clj
+++ b/yugabyte/src/yugabyte/ysql/append.clj
@@ -145,7 +145,14 @@
                                        (range keys-per-row)))
                                 {:conditional? true
                                  :table-spec   (geo-table-clause geo-partitioning)}))))
-         dorun))
+         dorun)
+    (if (= geo-partitioning :geo)
+      (do
+        (yugabyte.auto/yb-admin :create_transaction_table :jepsen_1_transactions)
+        (yugabyte.auto/yb-admin :modify_table_placement_info :system :jepsen_1_transactions "gcp.jepsen-1.jepsen-1a" 3)
+        (yugabyte.auto/yb-admin :create_transaction_table :jepsen_2_transactions)
+        (yugabyte.auto/yb-admin :modify_table_placement_info :system :jepsen_2_transactions "gcp.jepsen-2.jepsen-2a" 3)))
+    )
 
   (invoke-op! [this test op c conn-wrapper]
     (let [txn (:value op)

--- a/yugabyte/src/yugabyte/ysql/append.clj
+++ b/yugabyte/src/yugabyte/ysql/append.clj
@@ -196,7 +196,7 @@
                      "PARTITION OF " table " (k, k2, geo_partition"
                      ;", PRIMARY KEY (k, geo_partition)) FOR VALUES IN ('" postfix "') "
                      ") FOR VALUES IN ('" postfix "') "
-                     "TABLESPACE " tablespace-name "_" postfix
+                     ;"TABLESPACE " tablespace-name "_" postfix
                      )))
 
 (defrecord InternalClient [isolation locking geo-partitioning]

--- a/yugabyte/src/yugabyte/ysql/append.clj
+++ b/yugabyte/src/yugabyte/ysql/append.clj
@@ -186,7 +186,7 @@
     ""))
 
 (defn create-partitioning-table
-  [table tablespace-name postfix]
+  [c table tablespace-name postfix]
   (info "Create table partitions for " table "_" postfix " for '" postfix "'")
   (c/execute! c (str "CREATE TABLE " table "_" postfix " "
                      "PARTITION OF " table " (k, k2, geo_partition, "
@@ -215,8 +215,8 @@
                                    :table-spec   (get-table-spec geo-partitioning)}))
                   (if (= geo-partitioning :geo)
                     (do
-                      (create-partitioning-table table tablespace-name "1a")
-                      (create-partitioning-table table tablespace-name "2a")))))
+                      (create-partitioning-table c table tablespace-name "1a")
+                      (create-partitioning-table c table tablespace-name "2a")))))
            dorun)))
 
   (invoke-op! [this test op c conn-wrapper]

--- a/yugabyte/src/yugabyte/ysql/append.clj
+++ b/yugabyte/src/yugabyte/ysql/append.clj
@@ -187,7 +187,7 @@
   [geo-partitioning]
   (if (= geo-partitioning :geo)
     ""
-    ;"PARTITION BY LIST (geo_partition)"
+    "PARTITION BY LIST (geo_partition)"
     ""))
 
 (defn create-partitioning-table
@@ -196,7 +196,7 @@
   (c/execute! c (str "CREATE TABLE " table "_" postfix " "
                      "PARTITION OF " table " (k, k2, geo_partition, "
                      "PRIMARY KEY (k, geo_partition)) FOR VALUES IN ('" postfix "') "
-                     ;"TABLESPACE " tablespace-name "_" postfix
+                     "TABLESPACE " tablespace-name "_" postfix
                      )))
 
 (defrecord InternalClient [isolation locking geo-partitioning]
@@ -205,7 +205,7 @@
   (setup-cluster! [this test c conn-wrapper]
     (let [tablespace-name "geo_tablespace"]
       (info "Create tablespace " tablespace-name)
-      ;(setup-geo-partition c geo-partitioning tablespace-name)
+      (setup-geo-partition c geo-partitioning tablespace-name)
       (->> (range (table-count test))
            (map table-name)
            (map (fn [table]
@@ -219,10 +219,10 @@
                                          (range keys-per-row)))
                                   {:conditional? true
                                    :table-spec   (get-table-spec geo-partitioning)}))
-                  ;(if (= geo-partitioning :geo)
-                  ;  (do
-                  ;    (create-partitioning-table c table tablespace-name "1a")
-                  ;    (create-partitioning-table c table tablespace-name "2a")))
+                  (if (= geo-partitioning :geo)
+                    (do
+                      (create-partitioning-table c table tablespace-name "1a")
+                      (create-partitioning-table c table tablespace-name "2a")))
                   ))
            dorun)))
 

--- a/yugabyte/src/yugabyte/ysql/append.clj
+++ b/yugabyte/src/yugabyte/ysql/append.clj
@@ -200,8 +200,8 @@
                       (c/execute! c (str "CREATE TABLE " table "_2a"
                                          "PARTITION OF " table " (k, k2, geo_partition) "
                                          "PRIMARY KEY (k) FOR VALUES IN ('2a') "
-                                         "TABLESPACE (" tablespace-name "_2a)")))))))
-           dorun))
+                                         "TABLESPACE (" tablespace-name "_2a)"))))))
+           dorun)))
 
   (invoke-op! [this test op c conn-wrapper]
     (let [txn (:value op)

--- a/yugabyte/src/yugabyte/ysql/append.clj
+++ b/yugabyte/src/yugabyte/ysql/append.clj
@@ -85,7 +85,7 @@
                     [(str "insert into " table
                           " (k, k2, " col ")"
                           " values (?, ?, ?)") row row v]))
-    ;)
+    )
     v))
 
 (defn read-secondary

--- a/yugabyte/src/yugabyte/ysql/append.clj
+++ b/yugabyte/src/yugabyte/ysql/append.clj
@@ -40,7 +40,7 @@
 (defn get-geo-insert-column
   [geo-partitioning]
   (if (= geo-partitioning :geo)
-    (str ", geo_partition"))
+    (str ", geo_partition")
     "")
 
 (defn get-geo-insert-row

--- a/yugabyte/src/yugabyte/ysql/append.clj
+++ b/yugabyte/src/yugabyte/ysql/append.clj
@@ -51,7 +51,7 @@
     (str "select (" col ") from " table " where k = ?" clause)))
 
 (defn insert-primary-geo
-  [conn table geo-partitioning row v geo-row]
+  [conn table geo-partitioning col row v geo-row]
   (c/execute! conn
               [(str "insert into " table
                     " (k, k2, " col (get-geo-insert-column geo-partitioning) ")"
@@ -79,8 +79,8 @@
       ; No rows updated
       (if (= geo-partitioning :geo)
         (if (mod v 2)
-          (insert-primary-geo conn table geo-partitioning row v "'1a'")
-          (insert-primary-geo conn table geo-partitioning row v "'2a'"))
+          (insert-primary-geo conn table geo-partitioning col row v "'1a'")
+          (insert-primary-geo conn table geo-partitioning col row v "'2a'"))
         (c/execute! conn
                     [(str "insert into " table
                           " (k, k2, " col (get-geo-insert-column geo-partitioning) ")"

--- a/yugabyte/src/yugabyte/ysql/append.clj
+++ b/yugabyte/src/yugabyte/ysql/append.clj
@@ -130,12 +130,6 @@
 
   (setup-cluster! [this test c conn-wrapper]
     (setup-geo-partition c geo-partitioning)
-    (if (clojure.string/includes? (name (:workload test)) "geo.")
-      (do
-        (yugabyte.auto/yb-admin test :create_transaction_table :transactions_jepsen_1)
-        (yugabyte.auto/yb-admin test :modify_table_placement_info :system :transactions_jepsen_1 "gcp.jepsen-1.jepsen-1a" 3)
-        (yugabyte.auto/yb-admin test :create_transaction_table :transactions_jepsen_1)
-        (yugabyte.auto/yb-admin test :modify_table_placement_info :system :transactions_jepsen_2 "gcp.jepsen-2.jepsen-2a" 3)))
     (->> (range (table-count test))
          (map table-name)
          (map (fn [table]

--- a/yugabyte/src/yugabyte/ysql/append.clj
+++ b/yugabyte/src/yugabyte/ysql/append.clj
@@ -55,7 +55,7 @@
   (c/execute! conn
               [(str "insert into " table
                     " (k, k2, " col (get-geo-insert-column geo-partitioning) ")"
-                    " values (?, ?, ?" (if (= geo-partitioning :geo) ", ?" "") ")") row row v geo-row]))
+                    " values (?, ?, ?, ?)") row row v geo-row]))
 
 (defn read-primary
   "Reads a key based on primary key"

--- a/yugabyte/src/yugabyte/ysql/append.clj
+++ b/yugabyte/src/yugabyte/ysql/append.clj
@@ -70,6 +70,7 @@
   (let [r (c/execute! conn [(str "update " table
                                  " set " col " = CONCAT(" col ", ',', ?) "
                                  "where k = ?") v row])]
+    (info geo-partitioning conn table row col v)
     (when (= [0] r)
       ; No rows updated
       (c/execute! conn
@@ -110,8 +111,8 @@
   [geo-partitioning locking conn test [f k v]]
   (let [table (table-for test k)
         row (row-for test k)
-        col (col-for test k)
-        geo? ()]
+        col (col-for test k)]
+    (info geo-partitioning locking conn test [f k v])
     [f k (case f
            :r
            (read-primary locking conn table row col)

--- a/yugabyte/src/yugabyte/ysql/append.clj
+++ b/yugabyte/src/yugabyte/ysql/append.clj
@@ -112,7 +112,7 @@
 (defn create-geo-tablespace
   [conn table-name replica-placement]
   (j/execute! conn
-              [(str "CREATE TABLESPACE " table-name
+              [(str "CREATE TABLESPACE " table-name " "
                     "WITH (replica_placement='" (json/write-str replica-placement) "');")]
               {:transaction? false}))
 

--- a/yugabyte/src/yugabyte/ysql/append.clj
+++ b/yugabyte/src/yugabyte/ysql/append.clj
@@ -200,7 +200,7 @@
                                          "PARTITION OF " table " (k, k2, geo_partition) "
                                          "PRIMARY KEY (k) FOR VALUES IN ('2a') "
                                          "TABLESPACE (" tablespace-name "_2a)")))))))
-           dorun)))
+           dorun))
 
   (invoke-op! [this test op c conn-wrapper]
     (let [txn (:value op)

--- a/yugabyte/src/yugabyte/ysql/append.clj
+++ b/yugabyte/src/yugabyte/ysql/append.clj
@@ -129,7 +129,9 @@
 
 (defn create-geo-tablespace
   [conn table-name replica-placement]
-  (c/execute! conn
+  (info (str "CREATE TABLESPACE " table-name " "
+             "WITH (replica_placement='" (json/write-str replica-placement) "');"))
+  (j/execute! conn
               [(str "CREATE TABLESPACE " table-name " "
                     "WITH (replica_placement='" (json/write-str replica-placement) "');")]
               {:transaction? false}))

--- a/yugabyte/src/yugabyte/ysql/append.clj
+++ b/yugabyte/src/yugabyte/ysql/append.clj
@@ -195,7 +195,7 @@
                      "PARTITION OF " table " (k, k2, geo_partition"
                      ;", PRIMARY KEY (k, geo_partition)) FOR VALUES IN ('" postfix "') "
                      ") FOR VALUES IN ('" postfix "') "
-                     "TABLESPACE " tablespace-name "_" postfix
+                     ;"TABLESPACE " tablespace-name "_" postfix
                      )))
 
 (defrecord InternalClient [isolation locking geo-partitioning]

--- a/yugabyte/src/yugabyte/ysql/append.clj
+++ b/yugabyte/src/yugabyte/ysql/append.clj
@@ -187,7 +187,7 @@
 
 (defn create-partitioning-table
   [c table tablespace-name postfix]
-  (info "Create table partitions for " table "_" postfix " for '" postfix "'")
+  (info (str "Create table partitions for " table "_" postfix " for '" postfix "'"))
   (c/execute! c (str "CREATE TABLE " table "_" postfix " "
                      "PARTITION OF " table " (k, k2, geo_partition, "
                      "PRIMARY KEY (k, geo_partition)) FOR VALUES IN ('" postfix "') "

--- a/yugabyte/src/yugabyte/ysql/append.clj
+++ b/yugabyte/src/yugabyte/ysql/append.clj
@@ -128,12 +128,12 @@
                           {:cloud             :ybc
                            :region            :jepsen-1
                            :zone              :jepsen-1a
-                           :min_num_preplicas 1
+                           :min_num_replicas  1
                            :leader_preference 1}
                           {:cloud             :ybc
                            :region            :jepsen-2
                            :zone              :jepsen-2a
-                           :min_num_preplicas 1
+                           :min_num_replicas  1
                            :leader_preference 2},
                           ]
        })))

--- a/yugabyte/src/yugabyte/ysql/append.clj
+++ b/yugabyte/src/yugabyte/ysql/append.clj
@@ -175,10 +175,10 @@
 (defn get-create-table-columns-clause
   [geo-partitioning]
   (if (= geo-partitioning :geo)
-    [[:k :int "PRIMARY KEY"]
+    [[:k :int]
      [:k2 :int]
-     ;[:geo_partition :varchar]
-     ]
+     [:geo_partition :varchar]
+     "PRIMARY KEY (k, geo_partition)"]
     [;[:k :int "unique"]
      [:k :int "PRIMARY KEY"]
      [:k2 :int]]))

--- a/yugabyte/src/yugabyte/ysql/append.clj
+++ b/yugabyte/src/yugabyte/ysql/append.clj
@@ -128,10 +128,10 @@
   c/YSQLYbClient
 
   (setup-cluster! [this test c conn-wrapper]
+    (setup-geo-partition c geo-partitioning)
     (->> (range (table-count test))
          (map table-name)
          (map (fn [table]
-                (setup-geo-partition c geo-partitioning)
                 (info "Creating table" table)
                 (c/execute! c (j/create-table-ddl
                                 table

--- a/yugabyte/src/yugabyte/ysql/append.clj
+++ b/yugabyte/src/yugabyte/ysql/append.clj
@@ -184,7 +184,8 @@
 (defn get-table-spec
   [geo-partitioning]
   (if (= geo-partitioning :geo)
-    "PARTITION BY LIST (geo_partition)"
+    ""
+    ;"PARTITION BY LIST (geo_partition)"
     ""))
 
 (defn create-partitioning-table
@@ -216,10 +217,11 @@
                                          (range keys-per-row)))
                                   {:conditional? true
                                    :table-spec   (get-table-spec geo-partitioning)}))
-                  (if (= geo-partitioning :geo)
-                    (do
-                      (create-partitioning-table c table tablespace-name "1a")
-                      (create-partitioning-table c table tablespace-name "2a")))))
+                  ;(if (= geo-partitioning :geo)
+                  ;  (do
+                  ;    (create-partitioning-table c table tablespace-name "1a")
+                  ;    (create-partitioning-table c table tablespace-name "2a")))
+                  ))
            dorun)))
 
   (invoke-op! [this test op c conn-wrapper]

--- a/yugabyte/src/yugabyte/ysql/append.clj
+++ b/yugabyte/src/yugabyte/ysql/append.clj
@@ -148,10 +148,10 @@
          dorun)
     (if (= geo-partitioning :geo)
       (do
-        (yugabyte.auto/yb-admin :create_transaction_table :jepsen_1_transactions)
-        (yugabyte.auto/yb-admin :modify_table_placement_info :system :jepsen_1_transactions "gcp.jepsen-1.jepsen-1a" 3)
-        (yugabyte.auto/yb-admin :create_transaction_table :jepsen_2_transactions)
-        (yugabyte.auto/yb-admin :modify_table_placement_info :system :jepsen_2_transactions "gcp.jepsen-2.jepsen-2a" 3)))
+        (yugabyte.auto/yb-admin test :create_transaction_table :jepsen_1_transactions)
+        (yugabyte.auto/yb-admin test :modify_table_placement_info :system :jepsen_1_transactions "gcp.jepsen-1.jepsen-1a" 3)
+        (yugabyte.auto/yb-admin test :create_transaction_table :jepsen_2_transactions)
+        (yugabyte.auto/yb-admin test :modify_table_placement_info :system :jepsen_2_transactions "gcp.jepsen-2.jepsen-2a" 3)))
     )
 
   (invoke-op! [this test op c conn-wrapper]

--- a/yugabyte/src/yugabyte/ysql/append.clj
+++ b/yugabyte/src/yugabyte/ysql/append.clj
@@ -77,10 +77,10 @@
                                  "where k = ?") v row])]
     (when (= [0] r)
       ; No rows updated
-      ;(if (= geo-partitioning :geo)
-      ;  (if (mod v 2)
-      ;    (insert-primary-geo conn table geo-partitioning col row v "1a")
-      ;    (insert-primary-geo conn table geo-partitioning col row v "2a"))
+      (if (= geo-partitioning :geo)
+        (if (mod v 2)
+          (insert-primary-geo conn table geo-partitioning col row v "1a")
+          (insert-primary-geo conn table geo-partitioning col row v "2a"))
         (c/execute! conn
                     [(str "insert into " table
                           " (k, k2, " col ")"

--- a/yugabyte/src/yugabyte/ysql/append.clj
+++ b/yugabyte/src/yugabyte/ysql/append.clj
@@ -77,7 +77,7 @@
                                  " set " col " = CONCAT(" col ", ',', ?) "
                                  "where k = ?") v row])]
     (info (str "insert into " table
-               " (k, k2, " col (get-geo-insert-row geo-partitioning v) ")"
+               " (k, k2, " col (get-geo-insert-column geo-partitioning) ")"
                " values (?, ?, ?" (if (= geo-partitioning :geo) ",?" "") ")"))
     (when (= [0] r)
       ; No rows updated

--- a/yugabyte/src/yugabyte/ysql/append.clj
+++ b/yugabyte/src/yugabyte/ysql/append.clj
@@ -83,7 +83,7 @@
       ;    (insert-primary-geo conn table geo-partitioning col row v "2a"))
         (c/execute! conn
                     [(str "insert into " table
-                          " (k, k2, " col (get-geo-insert-column geo-partitioning) ")"
+                          " (k, k2, " col ")"
                           " values (?, ?, ?)") row row v]))
     ;)
     v))

--- a/yugabyte/src/yugabyte/ysql/append.clj
+++ b/yugabyte/src/yugabyte/ysql/append.clj
@@ -38,7 +38,7 @@
   (str "v" (mod k keys-per-row)))
 
 (defn get-geo-insert-column
-  [geo-partitioning v]
+  [geo-partitioning]
   (if (= geo-partitioning :geo)
     (str ", geo_partition"))
     "")
@@ -83,7 +83,7 @@
       ; No rows updated
       (c/execute! conn
                   [(str "insert into " table
-                        " (k, k2, " col (get-geo-insert-row geo-partitioning v) ")"
+                        " (k, k2, " col (get-geo-insert-column geo-partitioning) ")"
                         " values (?, ?, ?" (if (= geo-partitioning :geo) ",?" "") ")") row row v]))
     v))
 

--- a/yugabyte/src/yugabyte/ysql/append.clj
+++ b/yugabyte/src/yugabyte/ysql/append.clj
@@ -145,14 +145,7 @@
                                        (range keys-per-row)))
                                 {:conditional? true
                                  :table-spec   (geo-table-clause geo-partitioning)}))))
-         dorun)
-    (if (= geo-partitioning :geo)
-      (do
-        (yugabyte.auto/yb-admin test :create_transaction_table :jepsen_1_transactions)
-        (yugabyte.auto/yb-admin test :modify_table_placement_info :system :jepsen_1_transactions "gcp.jepsen-1.jepsen-1a" 3)
-        (yugabyte.auto/yb-admin test :create_transaction_table :jepsen_2_transactions)
-        (yugabyte.auto/yb-admin test :modify_table_placement_info :system :jepsen_2_transactions "gcp.jepsen-2.jepsen-2a" 3)))
-    )
+         dorun))
 
   (invoke-op! [this test op c conn-wrapper]
     (let [txn (:value op)

--- a/yugabyte/src/yugabyte/ysql/append.clj
+++ b/yugabyte/src/yugabyte/ysql/append.clj
@@ -165,7 +165,7 @@
   (if (= geo-partitioning :geo)
     [[:k :int "PRIMARY KEY"]
      [:k2 :int]
-     [:geo_partition :varchar]]
+     [:geo_partition :varchar "PRIMARY KEY"]]
     [;[:k :int "unique"]
      [:k :int "PRIMARY KEY"]
      [:k2 :int]]))

--- a/yugabyte/src/yugabyte/ysql/append.clj
+++ b/yugabyte/src/yugabyte/ysql/append.clj
@@ -41,7 +41,7 @@
   [geo-partitioning]
   (if (= geo-partitioning :geo)
     (str ", geo_partition")
-    "")
+    ""))
 
 (defn get-geo-insert-row
   [geo-partitioning v]

--- a/yugabyte/src/yugabyte/ysql/append.clj
+++ b/yugabyte/src/yugabyte/ysql/append.clj
@@ -178,7 +178,8 @@
     [[:k :int]
      [:k2 :int]
      [:geo_partition :varchar]
-     ["PRIMARY KEY (k, geo_partition)"] ]
+     ;["PRIMARY KEY (k, geo_partition)"]
+     ]
     [;[:k :int "unique"]
      [:k :int "PRIMARY KEY"]
      [:k2 :int]]))
@@ -194,8 +195,8 @@
   (info (str "Create table partitions for " table "_" postfix " for '" postfix "'"))
   (c/execute! c (str "CREATE TABLE " table "_" postfix " "
                      "PARTITION OF " table " (k, k2, geo_partition"
-                     ;", PRIMARY KEY (k, geo_partition)) FOR VALUES IN ('" postfix "') "
-                     ") FOR VALUES IN ('" postfix "') "
+                     ", PRIMARY KEY (k, geo_partition)) FOR VALUES IN ('" postfix "') "
+                     ;") FOR VALUES IN ('" postfix "') "
                      ;"TABLESPACE " tablespace-name "_" postfix
                      )))
 

--- a/yugabyte/src/yugabyte/ysql/append.clj
+++ b/yugabyte/src/yugabyte/ysql/append.clj
@@ -193,8 +193,9 @@
   [c table tablespace-name postfix]
   (info (str "Create table partitions for " table "_" postfix " for '" postfix "'"))
   (c/execute! c (str "CREATE TABLE " table "_" postfix " "
-                     "PARTITION OF " table " (k, k2, geo_partition, "
-                     "PRIMARY KEY (k, geo_partition)) FOR VALUES IN ('" postfix "') "
+                     "PARTITION OF " table " (k, k2, geo_partition"
+                     ;", PRIMARY KEY (k, geo_partition)) FOR VALUES IN ('" postfix "') "
+                     ") FOR VALUES IN ('" postfix "') "
                      "TABLESPACE " tablespace-name "_" postfix
                      )))
 

--- a/yugabyte/src/yugabyte/ysql/append.clj
+++ b/yugabyte/src/yugabyte/ysql/append.clj
@@ -70,6 +70,9 @@
   (let [r (c/execute! conn [(str "update " table
                                  " set " col " = CONCAT(" col ", ',', ?) "
                                  "where k = ?") v row])]
+    (info (str "insert into " table
+               " (k, k2, " col (get-geo-insert-row geo-partitioning v) ")"
+               " values (?, ?, ?" (if (= geo-partitioning :geo) ",?" "") ")"))
     (when (= [0] r)
       ; No rows updated
       (c/execute! conn

--- a/yugabyte/src/yugabyte/ysql/append.clj
+++ b/yugabyte/src/yugabyte/ysql/append.clj
@@ -199,15 +199,11 @@
                   (if (= geo-partitioning :geo)
                     (do
                       (info "Create table partitions for " table)
-                      (info (str "CREATE TABLE " table "_1a"
-                                 "PARTITION OF " table " (k, k2, geo_partition, "
-                                 "PRIMARY KEY (k, geo_partition)) FOR VALUES IN ('1a') "
-                                 "TABLESPACE " tablespace-name "_1a"))
-                      (c/execute! c (str "CREATE TABLE " table "_1a"
+                      (c/execute! c (str "CREATE TABLE " table "_1a "
                                          "PARTITION OF " table " (k, k2, geo_partition, "
                                          "PRIMARY KEY (k, geo_partition)) FOR VALUES IN ('1a') "
                                          "TABLESPACE " tablespace-name "_1a"))
-                      (c/execute! c (str "CREATE TABLE " table "_2a"
+                      (c/execute! c (str "CREATE TABLE " table "_2a "
                                          "PARTITION OF " table " (k, k2, geo_partition, "
                                          "PRIMARY KEY (k, geo_partition)) FOR VALUES IN ('2a') "
                                          "TABLESPACE " tablespace-name "_2a"))))))

--- a/yugabyte/src/yugabyte/ysql/append.clj
+++ b/yugabyte/src/yugabyte/ysql/append.clj
@@ -129,7 +129,7 @@
 
 (defn create-geo-tablespace
   [conn table-name replica-placement]
-  (j/execute! conn
+  (c/execute! conn
               [(str "CREATE TABLESPACE " table-name " "
                     "WITH (replica_placement='" (json/write-str replica-placement) "');")]
               {:transaction? false}))

--- a/yugabyte/src/yugabyte/ysql/append.clj
+++ b/yugabyte/src/yugabyte/ysql/append.clj
@@ -79,8 +79,8 @@
       ; No rows updated
       (if (= geo-partitioning :geo)
         (if (mod v 2)
-          (insert-primary-geo conn table geo-partitioning col row v "'1a'")
-          (insert-primary-geo conn table geo-partitioning col row v "'2a'"))
+          (insert-primary-geo conn table geo-partitioning col row v "1a")
+          (insert-primary-geo conn table geo-partitioning col row v "2a"))
         (c/execute! conn
                     [(str "insert into " table
                           " (k, k2, " col (get-geo-insert-column geo-partitioning) ")"

--- a/yugabyte/src/yugabyte/ysql/append.clj
+++ b/yugabyte/src/yugabyte/ysql/append.clj
@@ -193,7 +193,8 @@
   (c/execute! c (str "CREATE TABLE " table "_" postfix " "
                      "PARTITION OF " table " (k, k2, geo_partition, "
                      "PRIMARY KEY (k, geo_partition)) FOR VALUES IN ('" postfix "') "
-                     "TABLESPACE " tablespace-name "_" postfix)))
+                     ;"TABLESPACE " tablespace-name "_" postfix
+                     )))
 
 (defrecord InternalClient [isolation locking geo-partitioning]
   c/YSQLYbClient
@@ -201,7 +202,7 @@
   (setup-cluster! [this test c conn-wrapper]
     (let [tablespace-name "geo_tablespace"]
       (info "Create tablespace " tablespace-name)
-      (setup-geo-partition c geo-partitioning tablespace-name)
+      ;(setup-geo-partition c geo-partitioning tablespace-name)
       (->> (range (table-count test))
            (map table-name)
            (map (fn [table]

--- a/yugabyte/src/yugabyte/ysql/append.clj
+++ b/yugabyte/src/yugabyte/ysql/append.clj
@@ -202,11 +202,11 @@
                       (c/execute! c (str "CREATE TABLE " table "_1a"
                                          "PARTITION OF " table " (k, k2, geo_partition, "
                                          "PRIMARY KEY (k, geo_partition)) FOR VALUES IN ('1a') "
-                                         "TABLESPACE (" tablespace-name "_1a)"))
+                                         "TABLESPACE " tablespace-name "_1a"))
                       (c/execute! c (str "CREATE TABLE " table "_2a"
                                          "PARTITION OF " table " (k, k2, geo_partition, "
                                          "PRIMARY KEY (k, geo_partition)) FOR VALUES IN ('2a') "
-                                         "TABLESPACE (" tablespace-name "_2a)"))))))
+                                         "TABLESPACE " tablespace-name "_2a"))))))
            dorun)))
 
   (invoke-op! [this test op c conn-wrapper]

--- a/yugabyte/src/yugabyte/ysql/append.clj
+++ b/yugabyte/src/yugabyte/ysql/append.clj
@@ -123,8 +123,8 @@
 (defn geo-table-clause
   [geo-partitioning]
   (if (= geo-partitioning :geo)
-    ("TABLESPACE geo_tablespace")
-    ("")))
+    "TABLESPACE geo_tablespace"
+    ""))
 
 (defrecord InternalClient [isolation locking geo-partitioning]
   c/YSQLYbClient

--- a/yugabyte/src/yugabyte/ysql/append.clj
+++ b/yugabyte/src/yugabyte/ysql/append.clj
@@ -41,7 +41,7 @@
   [geo-partitioning v]
   (if (= geo-partitioning :geo)
     (str ", geo_partition"))
-    ""))
+    "")
 
 (defn get-geo-insert-row
   [geo-partitioning v]

--- a/yugabyte/src/yugabyte/ysql/append.clj
+++ b/yugabyte/src/yugabyte/ysql/append.clj
@@ -54,7 +54,7 @@
 
 (defn read-primary
   "Reads a key based on primary key"
-  [geo-partitioning locking conn table row col]
+  [locking conn table row col]
   (some-> conn
           (c/query [(select-with-lock locking col table) row])
           first
@@ -74,7 +74,8 @@
       ; No rows updated
       (c/execute! conn
                   [(str "insert into " table
-                        " (k, k2, " col (get-geo-insert-row geo-partitioning v) ") values (?, ?, ?)") row row v]))
+                        " (k, k2, " col (get-geo-insert-row geo-partitioning v) ")"
+                        " values (?, ?, ?" (if (= geo-partitioning :geo) ",?" "") ")") row row v]))
     v))
 
 (defn read-secondary
@@ -113,7 +114,7 @@
         geo? ()]
     [f k (case f
            :r
-           (read-primary geo-partitioning locking conn table row col)
+           (read-primary locking conn table row col)
 
            :append
            (append-primary! geo-partitioning conn table row col v))]))

--- a/yugabyte/src/yugabyte/ysql/append.clj
+++ b/yugabyte/src/yugabyte/ysql/append.clj
@@ -199,6 +199,10 @@
                   (if (= geo-partitioning :geo)
                     (do
                       (info "Create table partitions for " table)
+                      (info (str "CREATE TABLE " table "_1a"
+                                 "PARTITION OF " table " (k, k2, geo_partition, "
+                                 "PRIMARY KEY (k, geo_partition)) FOR VALUES IN ('1a') "
+                                 "TABLESPACE " tablespace-name "_1a"))
                       (c/execute! c (str "CREATE TABLE " table "_1a"
                                          "PARTITION OF " table " (k, k2, geo_partition, "
                                          "PRIMARY KEY (k, geo_partition)) FOR VALUES IN ('1a') "

--- a/yugabyte/src/yugabyte/ysql/append_table.clj
+++ b/yugabyte/src/yugabyte/ysql/append_table.clj
@@ -14,15 +14,8 @@
   they might not reflect commit orders, and there's no way to get (presently)
   txn commit times. We can use COUNT(*), but that reads the whole table... Not
   sure what to do here."
-  (:require [clojure.string :as str]
-            [clojure.java.jdbc :as j]
+  (:require [clojure.java.jdbc :as j]
             [clojure.tools.logging :refer [info]]
-            [jepsen [client :as client]
-                    [checker :as checker]
-                    [generator :as gen]
-                    [util :as util]]
-            [jepsen.tests.cycle :as cycle]
-            [jepsen.tests.cycle.append :as append]
             [yugabyte.ysql.client :as c]))
 
 (defn table-name

--- a/yugabyte/src/yugabyte/ysql/bank.clj
+++ b/yugabyte/src/yugabyte/ysql/bank.clj
@@ -1,9 +1,6 @@
 (ns yugabyte.ysql.bank
   (:require [clojure.java.jdbc :as j]
-            [clojure.string :as str]
             [clojure.tools.logging :refer [debug info warn]]
-            [jepsen.client :as client]
-            [jepsen.reconnect :as rc]
             [yugabyte.ysql.client :as c]))
 
 (def table-name "accounts")

--- a/yugabyte/src/yugabyte/ysql/client.clj
+++ b/yugabyte/src/yugabyte/ysql/client.clj
@@ -73,8 +73,10 @@
 (defn execute!
   "Like jdbc execute!, but includes a default timeout and (optionally) :op-index comment."
   ([op conn sql-params]
+   (info sql-params)
    (execute! conn (append-op-index op sql-params)))
   ([conn sql-params]
+   (info sql-params)
    (j/execute! conn sql-params {:timeout default-timeout})))
 
 (defn select-first-row

--- a/yugabyte/src/yugabyte/ysql/client.clj
+++ b/yugabyte/src/yugabyte/ysql/client.clj
@@ -73,10 +73,8 @@
 (defn execute!
   "Like jdbc execute!, but includes a default timeout and (optionally) :op-index comment."
   ([op conn sql-params]
-   (info sql-params)
    (execute! conn (append-op-index op sql-params)))
   ([conn sql-params]
-   (info sql-params)
    (j/execute! conn sql-params {:timeout default-timeout})))
 
 (defn select-first-row

--- a/yugabyte/src/yugabyte/ysql/default_value.clj
+++ b/yugabyte/src/yugabyte/ysql/default_value.clj
@@ -9,15 +9,8 @@
   value of `0` to an existing table, and execute concurrent inserts into the
   table, and concurrent reads, looking for cases where the column exists, but
   its value is `null` instead."
-  (:require [clojure.string :as str]
-            [clojure.java.jdbc :as j]
+  (:require [clojure.java.jdbc :as j]
             [clojure.tools.logging :refer [info]]
-            [jepsen [client :as client]
-                    [checker :as checker]
-                    [generator :as gen]
-                    [util :as util]]
-            [jepsen.tests.cycle :as cycle]
-            [jepsen.tests.cycle.append :as append]
             [yugabyte.ysql.client :as c]))
 
 (def table "foo")

--- a/yugabyte/src/yugabyte/ysql/long_fork.clj
+++ b/yugabyte/src/yugabyte/ysql/long_fork.clj
@@ -1,8 +1,5 @@
 (ns yugabyte.ysql.long-fork
   (:require [clojure.java.jdbc :as j]
-            [clojure.tools.logging :refer [debug info warn]]
-            [jepsen.client :as client]
-            [jepsen.reconnect :as rc]
             [jepsen.tests.long-fork :as lf]
             [yugabyte.ysql.client :as c]))
 

--- a/yugabyte/src/yugabyte/ysql/multi_key_acid.clj
+++ b/yugabyte/src/yugabyte/ysql/multi_key_acid.clj
@@ -1,11 +1,7 @@
 (ns yugabyte.ysql.multi-key-acid
   "This test uses INSERT ... ON CONFLICT DO UPDATE"
   (:require [clojure.java.jdbc :as j]
-            [clojure.string :as str]
-            [clojure.tools.logging :refer [debug info warn]]
-            [jepsen.client :as client]
             [jepsen.independent :as independent]
-            [jepsen.reconnect :as rc]
             [jepsen.txn.micro-op :as mop]
             [yugabyte.ysql.client :as c]))
 

--- a/yugabyte/src/yugabyte/ysql/set.clj
+++ b/yugabyte/src/yugabyte/ysql/set.clj
@@ -1,9 +1,5 @@
 (ns yugabyte.ysql.set
   (:require [clojure.java.jdbc :as j]
-            [clojure.string :as str]
-            [clojure.tools.logging :refer [debug info warn]]
-            [jepsen.client :as client]
-            [jepsen.reconnect :as rc]
             [yugabyte.ysql.client :as c]))
 
 (def table-name "elements")

--- a/yugabyte/src/yugabyte/ysql/single_key_acid.clj
+++ b/yugabyte/src/yugabyte/ysql/single_key_acid.clj
@@ -1,10 +1,6 @@
 (ns yugabyte.ysql.single-key-acid
   (:require [clojure.java.jdbc :as j]
-            [clojure.string :as str]
-            [clojure.tools.logging :refer [debug info warn]]
-            [jepsen.client :as client]
             [jepsen.independent :as independent]
-            [jepsen.reconnect :as rc]
             [yugabyte.single-key-acid :as ska]
             [yugabyte.ysql.client :as c]))
 


### PR DESCRIPTION
Added geo-partitioned transactions case for append. Used 2 zones in test.

1. Started master and tserver nodes with following flags:
```
:--placement_cloud :ybc
:--placement_region (str "jepsen-" node-id-int)
:--placement_zone (str "jepsen-" node-id-int "a")
```
2. Evaluate `yb-admin` calls and create transaction tables for both zones
```
(yugabyte.auto/yb-admin test :create_transaction_table :transactions_jepsen_1)
(yugabyte.auto/yb-admin test :modify_table_placement_info :system :transactions_jepsen_1 "ybc.jepsen-1.jepsen-1a" 2)
```
3. Create tablespace with zone mapping
```
(str "CREATE TABLESPACE " table-name " WITH (replica_placement='" (json/write-str replica-placement) "');")
```
Where replica-placement is following json
```
{
       :num_replicas     3
       :placement_blocks [
                          {
                           :cloud             :ybc
                           :region            :jepsen-1
                           :zone              :jepsen-1a
                           :min_num_replicas  1
                           :leader_preference 1
                           }
                          {
                           :cloud             :ybc
                           :region            :jepsen-2
                           :zone              :jepsen-2a
                           :min_num_replicas  1
                           :leader_preference 2
                           }
                          ]
       }
```
4. Evaluate common append test