### PR TITLE
Updated YCQL driver, updated jepsen version and added print random seed

### DIFF
--- a/yugabyte/project.clj
+++ b/yugabyte/project.clj
@@ -6,8 +6,7 @@
   :dependencies [[org.clojure/clojure "1.11.1"]
                  [clj-http "3.12.3" :exclusions [commons-logging]]
                  [jepsen "0.3.10"]
-                 [com.yugabyte/cassaforte "3.0.0-alpha2-yb-1"
-                  :exclusions [org.slf4j/slf4j-api]]
+                 [com.yugabyte/cassandra-driver-core "3.10.3-yb-3"]
                  [org.slf4j/slf4j-api "2.0.17"]
                  [org.clojure/java.jdbc "0.7.12"]
                  [org.clojure/data.json "2.4.0"]

--- a/yugabyte/project.clj
+++ b/yugabyte/project.clj
@@ -6,7 +6,9 @@
   :dependencies [[org.clojure/clojure "1.11.1"]
                  [clj-http "3.12.3" :exclusions [commons-logging]]
                  [jepsen "0.3.10"]
-                 [com.yugabyte/cassaforte "3.0.0-alpha2-yb-1"]
+                 [com.yugabyte/cassaforte "3.0.0-alpha2-yb-1"
+                  :exclusions [org.slf4j/slf4j-api]]
+                 [org.slf4j/slf4j-api "2.0.17"]
                  [org.clojure/java.jdbc "0.7.12"]
                  [org.clojure/data.json "2.4.0"]
                  [com.yugabyte/jdbc-yugabytedb "42.3.5-yb-3"]

--- a/yugabyte/project.clj
+++ b/yugabyte/project.clj
@@ -5,7 +5,7 @@
             :url  "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.11.1"]
                  [clj-http "3.12.3" :exclusions [commons-logging]]
-                 [jepsen "0.3.7"]
+                 [jepsen "0.3.10"]
                  [com.yugabyte/cassaforte "3.0.0-alpha2-yb-1"]
                  [org.clojure/java.jdbc "0.7.12"]
                  [org.clojure/data.json "2.4.0"]

--- a/yugabyte/run-jepsen.py
+++ b/yugabyte/run-jepsen.py
@@ -443,7 +443,7 @@ def main():
     connection_manager_flag = "--connection-manager false" \
         if not (is_version_at_least("2024.1.0.0-b1", version) or
                 is_version_at_least("2.25.1.0-b1", version)) else ""
-    os.environ["JAVA_HOME"] = "/usr/lib/jvm/zulu-21.jdk"
+    os.environ["JAVA_HOME"] = "/usr/lib/jvm/zulu-17.jdk"
     java_version = subprocess.check_output(
         [os.path.join(os.environ["JAVA_HOME"], "bin", "java"), "-version"],
         stderr=subprocess.STDOUT).decode().strip()

--- a/yugabyte/run-jepsen.py
+++ b/yugabyte/run-jepsen.py
@@ -381,7 +381,7 @@ def parse_args():
         help='Enable clock skew nemesis. This will not work on LXC.')
     parser.add_argument(
         '--concurrency',
-        default='4n',
+        default='6n',
         help='Concurrency to specify, e.g. 2n, 4n, or 5n, where n means the number of nodes.')
     parser.add_argument(
         '--workloads',

--- a/yugabyte/run-jepsen.py
+++ b/yugabyte/run-jepsen.py
@@ -443,6 +443,7 @@ def main():
     connection_manager_flag = "--connection-manager false" \
         if not (is_version_at_least("2024.1.0.0-b1", version) or
                 is_version_at_least("2.25.1.0-b1", version)) else ""
+    os.environ["JAVA_HOME"] = "/usr/lib/jvm/zulu-25.jdk"
     lein_cmd = " ".join(["lein run test",
                          "--os debian",
                          f"--url {url}",

--- a/yugabyte/run-jepsen.py
+++ b/yugabyte/run-jepsen.py
@@ -443,7 +443,11 @@ def main():
     connection_manager_flag = "--connection-manager false" \
         if not (is_version_at_least("2024.1.0.0-b1", version) or
                 is_version_at_least("2.25.1.0-b1", version)) else ""
-    os.environ["JAVA_HOME"] = "/usr/lib/jvm/zulu-25.jdk"
+    os.environ["JAVA_HOME"] = "/usr/lib/jvm/zulu-21.jdk"
+    java_version = subprocess.check_output(
+        [os.path.join(os.environ["JAVA_HOME"], "bin", "java"), "-version"],
+        stderr=subprocess.STDOUT).decode().strip()
+    logging.info("Java version:\n%s", java_version)
     lein_cmd = " ".join(["lein run test",
                          "--os debian",
                          f"--url {url}",

--- a/yugabyte/src/yugabyte/auto.clj
+++ b/yugabyte/src/yugabyte/auto.clj
@@ -510,7 +510,7 @@
                 (c/su (let [post-install-script-path "./bin/post_install.sh"]
                         (info "Post-install script")
 
-                        (assert (= (count (cu/ls post-install-script-path)) 1)
+                        (assert (cu/exists? post-install-script-path)
                                 "Post-install script does not exist!")
                         (c/exec post-install-script-path)
 

--- a/yugabyte/src/yugabyte/auto.clj
+++ b/yugabyte/src/yugabyte/auto.clj
@@ -8,6 +8,7 @@
             [jepsen.control :as c]
             [jepsen.db :as db]
             [jepsen.util :as util :refer [meh]]
+            [jepsen.random :as random]
             [jepsen.control.net :as cn]
             [jepsen.control.util :as cu]
             [jepsen.os.debian :as debian]
@@ -399,7 +400,7 @@
 
 (defn get-random-node-skew
   [max_skew node_ip]
-  (rand-int max_skew))
+  (random/long max_skew))
 
 (def get-node-skew
   (memoize get-random-node-skew))

--- a/yugabyte/src/yugabyte/auto.clj
+++ b/yugabyte/src/yugabyte/auto.clj
@@ -329,7 +329,7 @@
   the symlinks which end in .INFO, .WARNING, etc."
   [dir]
   (remove (partial re-find #"\.(INFO|WARNING|ERROR)$")
-          (try (cu/ls-full dir)
+          (try (cu/ls dir {:full-path? true})
                (catch RuntimeException e nil))))
 
 ; Community-edition-specific files

--- a/yugabyte/src/yugabyte/bank_improved.clj
+++ b/yugabyte/src/yugabyte/bank_improved.clj
@@ -19,6 +19,7 @@
              [history :as h]
              [generator :as gen]
              [checker :as checker]
+             [random :as random]
              [util :as util]]))
 
 (def start-key 0)
@@ -33,21 +34,21 @@
   Generator of a transfer: a random amount between two randomly selected accounts.
   Added insert operation. Special case for YCQL"
   [test process]
-  (let [dice (rand-nth [:insert :update])]
+  (let [dice (random/nth [:insert :update])]
     (cond
       (= dice :insert)
       {:type  :invoke
        :f     dice
-       :value {:from   (rand-nth (:accounts test))
+       :value {:from   (random/nth (:accounts test))
                :to     (swap! insert-key-ctr inc)
-               :amount (+ 1 (rand-int (:max-transfer test)))}}
+               :amount (+ 1 (random/long (:max-transfer test)))}}
 
       (= dice :update)
       {:type  :invoke
        :f     dice
-       :value {:from   (rand-nth (:accounts test))
-               :to     (rand-nth (:accounts test))
-               :amount (+ 1 (rand-int (:max-transfer test)))}})))
+       :value {:from   (random/nth (:accounts test))
+               :to     (random/nth (:accounts test))
+               :amount (+ 1 (random/long (:max-transfer test)))}})))
 
 (defn transfer-contention-keys
   "Based on from original jepsen.tests.bank.transfer generator.
@@ -57,28 +58,28 @@
   A random amount between two randomly selected accounts with set of contention keys
   that may be inserted, deleted or updated."
   [test process]
-  (let [dice (rand-nth (:operations test))]
+  (let [dice (random/nth (:operations test))]
     (cond
       (= dice :insert)
       {:type  :invoke
        :f     dice
-       :value {:from   (rand-nth (:accounts test))
-               :to     (rand-nth contention-keys)
-               :amount (+ 1 (rand-int (:max-transfer test)))}}
+       :value {:from   (random/nth (:accounts test))
+               :to     (random/nth contention-keys)
+               :amount (+ 1 (random/long (:max-transfer test)))}}
 
       (= dice :update)
       {:type  :invoke
        :f     dice
-       :value {:from   (rand-nth (concat (:accounts test) contention-keys))
-               :to     (rand-nth (concat (:accounts test) contention-keys))
-               :amount (+ 1 (rand-int (:max-transfer test)))}}
+       :value {:from   (random/nth (concat (:accounts test) contention-keys))
+               :to     (random/nth (concat (:accounts test) contention-keys))
+               :amount (+ 1 (random/long (:max-transfer test)))}}
 
       (= dice :delete)
       {:type  :invoke
        :f     dice
-       :value {:from   (rand-nth contention-keys)
-               :to     (rand-nth (:accounts test))
-               :amount (+ 1 (rand-int (:max-transfer test)))}})))
+       :value {:from   (random/nth contention-keys)
+               :to     (random/nth (:accounts test))
+               :amount (+ 1 (random/long (:max-transfer test)))}})))
 
 (def diff-transfer-insert
   "Based on from original jepsen.tests.bank workload

--- a/yugabyte/src/yugabyte/core.clj
+++ b/yugabyte/src/yugabyte/core.clj
@@ -4,6 +4,7 @@
             [clojure.string :as str]
             [jepsen.checker :as checker]
             [jepsen.generator :as gen]
+            [jepsen.random :as random]
             [jepsen.tests :as tests]
             [jepsen.os.debian :as debian]
             [jepsen.os.centos :as centos]
@@ -313,8 +314,8 @@
 (defn test-3
   "Final phase where we define global cluster configuration parameters"
   [opts]
-  (let [packed-columns-enabled (> (rand) 0.5)
-        colocated (and (not (utils/is-test-geo-partitioned? opts)) (> (rand) 0.5))]
+  (let [packed-columns-enabled (random/bool)
+        colocated (and (not (utils/is-test-geo-partitioned? opts)) (random/bool))]
     (assoc opts :yb-packed-columns-enabled packed-columns-enabled :yb-colocated colocated)))
 
 (defn yb-test

--- a/yugabyte/src/yugabyte/multi_key_acid.clj
+++ b/yugabyte/src/yugabyte/multi_key_acid.clj
@@ -4,6 +4,7 @@
   Verify that history remains linearizable."
   (:require [jepsen.checker :as checker]
             [jepsen.generator :as gen]
+            [jepsen.random :as random]
             [jepsen.util :as util]
             [jepsen.independent :as independent]
             [knossos.model :as model]
@@ -37,7 +38,7 @@
 
 ; Three keys, five possible values per key.
 (def key-range (vec (range 3)))
-(defn rand-val [] (rand-int 5))
+(defn rand-val [] (random/long 5))
 
 (defn r
   "Read a random subset of keys."

--- a/yugabyte/src/yugabyte/runner.clj
+++ b/yugabyte/src/yugabyte/runner.clj
@@ -6,6 +6,7 @@
             [clojure.tools.logging :refer :all]
             [jepsen.core :as jepsen]
             [jepsen.cli :as cli]
+            [jepsen.random :as random]
             [jepsen.store :as store]
             [yugabyte.core :as core]))
 
@@ -116,7 +117,11 @@
     :default nil]
 
    [nil "--trace-cql" "If provided, logs CQL queries"
-    :default false]])
+    :default false]
+
+   [nil "--random-seed SEED" "Random seed for deterministic test execution. If not provided, a random seed is generated."
+    :default nil
+    :parse-fn parse-long]])
 
 (def test-all-opts
   "CLI options for testing everything."
@@ -135,6 +140,17 @@
     :parse-fn keyword
     :missing (str "--workload " (one-of core/workloads))
     :validate [core/workloads (one-of core/workloads)]]])
+
+(defn run-with-seed!
+  "Constructs and runs a Jepsen test. Takes a zero-arg function that builds the
+  test map. Wraps both construction and execution with jepsen.random/with-seed
+  for deterministic randomness. When seed is nil, defaults to
+  System/currentTimeMillis."
+  [test-fn seed]
+  (let [seed (or seed (System/currentTimeMillis))]
+    (info "Random seed:" seed)
+    (random/with-seed seed
+      (jepsen/run! (test-fn)))))
 
 ;
 ; Subcommands
@@ -165,16 +181,16 @@
                       results       (->> tests
                                          (map-indexed
                                            (fn [i test-opts]
-                                             (let [test (core/yb-test test-opts)]
-                                               (try
-                                                 (info "\n\n\nTest "
-                                                       (inc i) "/" (count tests))
-                                                 (let [test' (jepsen/run! test)]
-                                                   [(.getPath (store/path test'))
-                                                    (:valid? (:results test'))])
-                                                 (catch Exception e
-                                                   (warn e "Test crashed")
-                                                   [(:name test) :crashed])))))
+                                             (try
+                                               (info "\n\n\nTest "
+                                                     (inc i) "/" (count tests))
+                                               (let [test' (run-with-seed! #(core/yb-test test-opts)
+                                                                           (:random-seed options))]
+                                                 [(.getPath (store/path test'))
+                                                  (:valid? (:results test'))])
+                                               (catch Exception e
+                                                 (warn e "Test crashed")
+                                                 [(:name test-opts) :crashed]))))
                                          (group-by second))]
 
                   (println "\n")
@@ -201,12 +217,30 @@
                   (println (count (results :crashed)) "crashed")
                   (println (count (results false)) "failures")))}})
 
+(defn single-test-cmd
+  "A command that runs a single test, wrapping execution with a random seed."
+  []
+  (let [opt-spec (cli/merge-opt-specs cli/test-opt-spec
+                                      (concat cli-opts single-test-opts))
+        opt-fn   cli/test-opt-fn]
+    {"test" {:opt-spec opt-spec
+             :opt-fn   opt-fn
+             :usage    "Runs a single test"
+             :run      (fn [{:keys [options]}]
+                         (info "Test options:\n"
+                               (with-out-str (pprint options)))
+                         (doseq [i (range (:test-count options))]
+                           (let [test (run-with-seed! #(core/yb-test options)
+                                                      (:random-seed options))]
+                             (case (:valid? (:results test))
+                               false    (System/exit 1)
+                               :unknown (System/exit 2)
+                               nil))))}}))
+
 (defn -main
   "Handles CLI arguments"
   [& args]
   (cli/run! (merge (cli/serve-cmd)
                    (test-all-cmd)
-                   (cli/single-test-cmd {:test-fn  core/yb-test
-                                         :opt-spec (concat cli-opts
-                                                           single-test-opts)}))
+                   (single-test-cmd))
             args))

--- a/yugabyte/src/yugabyte/runner.clj
+++ b/yugabyte/src/yugabyte/runner.clj
@@ -145,12 +145,13 @@
   "Constructs and runs a Jepsen test. Takes a zero-arg function that builds the
   test map. Wraps both construction and execution with jepsen.random/with-seed
   for deterministic randomness. When seed is nil, defaults to
-  System/currentTimeMillis."
+  System/currentTimeMillis. Stores the seed in the test map as :random-seed
+  so it persists in results.edn."
   [test-fn seed]
   (let [seed (or seed (System/currentTimeMillis))]
     (info "Random seed:" seed)
     (random/with-seed seed
-      (jepsen/run! (test-fn)))))
+      (jepsen/run! (assoc (test-fn) :random-seed seed)))))
 
 ;
 ; Subcommands

--- a/yugabyte/src/yugabyte/single_key_acid.clj
+++ b/yugabyte/src/yugabyte/single_key_acid.clj
@@ -16,6 +16,7 @@
             [jepsen.checker :as checker]
             [jepsen.generator :as gen]
             [jepsen.independent :as independent]
+            [jepsen.random :as random]
             [knossos.model :as model]
             [yugabyte.generator :as ygen]
             [jepsen.checker.timeline :as timeline]))
@@ -23,8 +24,8 @@
 (def keys-count 2)
 
 (defn r [_ _] {:type :invoke, :f :read, :value nil})
-(defn w [_ _] {:type :invoke, :f :write, :value (rand-int keys-count)})
-(defn cas [_ _] {:type :invoke, :f :cas, :value [(rand-int keys-count) (rand-int keys-count)]})
+(defn w [_ _] {:type :invoke, :f :write, :value (random/long keys-count)})
+(defn cas [_ _] {:type :invoke, :f :cas, :value [(random/long keys-count) (random/long keys-count)]})
 
 (defn workload
   [opts]

--- a/yugabyte/src/yugabyte/ycql/bank.clj
+++ b/yugabyte/src/yugabyte/ycql/bank.clj
@@ -4,6 +4,7 @@
             [clojurewerkz.cassaforte.client :as cassandra]
             [clojurewerkz.cassaforte.cql :as cql]
             [clojurewerkz.cassaforte.query :as q :refer :all]
+            [jepsen.random :as random]
             [yugabyte.ycql.client :as c]))
 
 (def setup-lock (Object.))
@@ -77,7 +78,7 @@
     (c/with-errors op #{:read}
       (case (:f op)
         :read
-        (let [as (shuffle (:accounts test))]
+        (let [as (random/shuffle (:accounts test))]
           (->> as
                (mapv (fn [x]
                        ;; TODO - should be wrapped in a transaction after we

--- a/yugabyte/src/yugabyte/ycql/bank.clj
+++ b/yugabyte/src/yugabyte/ycql/bank.clj
@@ -1,9 +1,6 @@
 (ns yugabyte.ycql.bank
   (:refer-clojure :exclude [test])
   (:require [clojure.tools.logging :refer [debug info warn]]
-            [clojurewerkz.cassaforte.client :as cassandra]
-            [clojurewerkz.cassaforte.cql :as cql]
-            [clojurewerkz.cassaforte.query :as q :refer :all]
             [jepsen.random :as random]
             [yugabyte.ycql.client :as c]))
 
@@ -15,31 +12,31 @@
   (setup! [this test]
     (c/create-transactional-table
       conn table-name
-      (q/if-not-exists)
-      (q/column-definitions {:id      :int
-                             :balance :bigint
-                             :primary-key [:id]}))
+      {:id          :int
+       :balance     :bigint
+       :primary-key [:id]})
     (info "Creating accounts")
     (c/with-retry
-      (cql/insert-with-ks conn keyspace table-name
-                          {:id (first (:accounts test))
-                           :balance (:total-amount test)})
+      (c/insert! conn table-name
+                 {:id (first (:accounts test))
+                  :balance (:total-amount test)}
+                 :keyspace keyspace)
       (doseq [a (rest (:accounts test))]
-        (cql/insert conn table-name
-                    {:id a, :balance 0}))))
+        (c/insert! conn table-name
+                   {:id a, :balance 0}))))
 
   (invoke! [this test op]
     (c/with-errors op #{:read}
       (case (:f op)
         :read
-        (->> (cql/select-with-ks conn keyspace table-name)
+        (->> (c/select conn table-name :keyspace keyspace)
              (map (juxt :id :balance))
              (into (sorted-map))
              (assoc op :type :ok, :value))
 
         :transfer
         (let [{:keys [from to amount]} (:value op)]
-          (cassandra/execute
+          (c/execute!
             conn
             ; TODO: separate reads from updates?
             (str "BEGIN TRANSACTION "
@@ -61,18 +58,18 @@
       (info "Creating table" a)
       (c/create-transactional-table
         conn (str table-name a)
-        (q/if-not-exists)
-        (q/column-definitions {:id          :int
-                               :balance     :bigint
-                               :primary-key [:id]}))
+        {:id          :int
+         :balance     :bigint
+         :primary-key [:id]})
 
       (info "Populating account" a)
       (c/with-retry
-        (cql/insert-with-ks conn keyspace (str table-name a)
-                            {:id      a
-                             :balance (if (= a (first (:accounts test)))
-                                        (:total-amount test)
-                                        0)}))))
+        (c/insert! conn (str table-name a)
+                   {:id      a
+                    :balance (if (= a (first (:accounts test)))
+                               (:total-amount test)
+                               0)}
+                   :keyspace keyspace))))
 
   (invoke! [this test op]
     (c/with-errors op #{:read}
@@ -83,9 +80,9 @@
                (mapv (fn [x]
                        ;; TODO - should be wrapped in a transaction after we
                        ;; support transactions with selects.
-                       (->> (cql/select-with-ks conn keyspace
-                                                (str table-name x)
-                                                (where [[= :id x]]))
+                       (->> (c/select conn (str table-name x)
+                                      :keyspace keyspace
+                                      :where [[:= :id x]])
                             first
                             :balance)))
                (zipmap as)
@@ -93,15 +90,15 @@
 
         :transfer
         (let [{:keys [from to amount]} (:value op)]
-          (cassandra/execute conn
-                             (str "BEGIN TRANSACTION "
-                                  (str "UPDATE " keyspace "." table-name from
-                                       " SET balance = balance - " amount
-                                       " WHERE id = " from ";")
-                                  (str "UPDATE " keyspace "." table-name to
-                                       " SET balance = balance + " amount
-                                       " WHERE id = " to ";")
-                                  "END TRANSACTION;"))
+          (c/execute! conn
+                      (str "BEGIN TRANSACTION "
+                           (str "UPDATE " keyspace "." table-name from
+                                " SET balance = balance - " amount
+                                " WHERE id = " from ";")
+                           (str "UPDATE " keyspace "." table-name to
+                                " SET balance = balance + " amount
+                                " WHERE id = " to ";")
+                           "END TRANSACTION;"))
           (assoc op :type :ok)))))
 
   (teardown! [this test]))

--- a/yugabyte/src/yugabyte/ycql/bank_improved.clj
+++ b/yugabyte/src/yugabyte/ycql/bank_improved.clj
@@ -6,9 +6,6 @@
   (:refer-clojure :exclude
                   [test])
   (:require [clojure.tools.logging :refer [debug info warn]]
-            [clojurewerkz.cassaforte.client :as cassandra]
-            [clojurewerkz.cassaforte.cql :as cql]
-            [clojurewerkz.cassaforte.query :as q :refer :all]
             [yugabyte.ycql.client :as c]))
 
 (def keyspace "jepsen")
@@ -18,33 +15,32 @@
   (setup! [this test]
     (c/create-transactional-table
       conn table-name
-      (q/if-not-exists)
-      (q/column-definitions
-        {:id          :int
-         :balance     :bigint
-         :primary-key [:id]}))
+      {:id          :int
+       :balance     :bigint
+       :primary-key [:id]})
     (info "Creating accounts")
     (c/with-retry
-      (cql/insert-with-ks conn keyspace table-name
-                          {:id      (first (:accounts test))
-                           :balance (:total-amount test)})
+      (c/insert! conn table-name
+                 {:id      (first (:accounts test))
+                  :balance (:total-amount test)}
+                 :keyspace keyspace)
       (doseq [a (rest (:accounts test))]
-        (cql/insert conn table-name
-                    {:id a, :balance 0}))))
+        (c/insert! conn table-name
+                   {:id a, :balance 0}))))
 
   (invoke! [this test op]
     (c/with-errors
       op #{:read}
       (case (:f op)
         :read
-        (->> (cql/select-with-ks conn keyspace table-name)
+        (->> (c/select conn table-name :keyspace keyspace)
              (map (juxt :id :balance))
              (into (sorted-map))
              (assoc op :type :ok, :value))
 
         :update
         (let [{:keys [from to amount]} (:value op)]
-          (cassandra/execute
+          (c/execute!
             conn
             ; TODO: separate reads from updates?
             (str "BEGIN TRANSACTION "
@@ -58,7 +54,7 @@
 
         :insert
         (let [{:keys [from to amount]} (:value op)]
-          (cassandra/execute
+          (c/execute!
             conn
             (str "BEGIN TRANSACTION "
                  "INSERT INTO " keyspace "." table-name

--- a/yugabyte/src/yugabyte/ycql/client.clj
+++ b/yugabyte/src/yugabyte/ycql/client.clj
@@ -1,9 +1,6 @@
 (ns yugabyte.ycql.client
-  "Helper functions for working with Cassaforte clients."
-  (:require [clojurewerkz.cassaforte [client :as c]
-                                     [query :as q]
-                                     [policies :as policies]
-                                     [cql :as cql]]
+  "Helper functions for working with the DataStax Cassandra Java driver."
+  (:require [clojure.string :as str]
             [clojure.tools.logging :refer [info]]
             [jepsen [random :as random]
                     [util :as util]]
@@ -18,10 +15,16 @@
                                      NettyUtil
                                      PoolingOptions
                                      ProtocolVersion
+                                     ResultSet
+                                     Row
+                                     Session
+                                     SimpleStatement
                                      SocketOptions
                                      ThreadingOptions)
-           (com.datastax.driver.core.policies RoundRobinPolicy
+           (com.datastax.driver.core.policies ConstantReconnectionPolicy
+                                              RoundRobinPolicy
                                               WhiteListPolicy)
+           (com.yugabyte.driver.core.policies NoRetryOnClientTimeoutPolicy)
            (com.datastax.driver.core.exceptions DriverException
                                                 InvalidQueryException
                                                 UnavailableException
@@ -34,6 +37,182 @@
            (java.util.concurrent LinkedBlockingQueue
                                  ThreadPoolExecutor
                                  TimeUnit)))
+
+;; ---- Value & condition formatting ----
+
+(defn format-value
+  "Formats a Clojure value for inclusion in a CQL string."
+  [v]
+  (cond
+    (nil? v)    "null"
+    (number? v) (str v)
+    (string? v) (str "'" (str/replace v "'" "''") "'")
+    (keyword? v) (name v)
+    :else       (str v)))
+
+(defn format-condition
+  "Formats a condition vector like [:= :id 5] into a CQL fragment."
+  [[op col val]]
+  (let [col-name (name col)]
+    (case op
+      :=  (str col-name " = " (format-value val))
+      :in (str col-name " IN (" (str/join ", " (map format-value val)) ")"))))
+
+(defn format-conditions
+  "Joins condition vectors with AND."
+  [conds]
+  (str/join " AND " (map format-condition conds)))
+
+;; ---- ResultSet → Clojure maps ----
+
+(defn resultset->maps
+  "Converts a ResultSet into a vector of Clojure maps with keyword keys."
+  [^ResultSet rs]
+  (let [col-defs (.getColumnDefinitions rs)
+        n        (.size col-defs)
+        col-names (mapv #(keyword (.getName col-defs (int %))) (range n))]
+    (mapv (fn [^Row row]
+            (into {} (map-indexed
+                       (fn [i col-name]
+                         [col-name (.getObject row (int i))])
+                       col-names)))
+          (.all rs))))
+
+;; ---- Core execute ----
+
+(defn execute!
+  "Executes a CQL string on a session, returns a vector of maps."
+  [^Session session ^String cql]
+  (resultset->maps (.execute session (SimpleStatement. cql))))
+
+;; ---- Connection management ----
+
+(defn disconnect!
+  "Closes a session and its associated cluster."
+  [^Session session]
+  (let [cluster (.getCluster session)]
+    (try (.close session)
+         (finally
+           (.close cluster)))))
+
+;; ---- Keyspace management ----
+
+(defn create-keyspace!
+  "Creates a keyspace with SimpleStrategy replication if it doesn't exist."
+  [session ks-name replication-factor]
+  (execute! session
+            (str "CREATE KEYSPACE IF NOT EXISTS " ks-name
+                 " WITH replication = {'class': 'SimpleStrategy',"
+                 " 'replication_factor': " replication-factor "}")))
+
+(defn use-keyspace!
+  "Sets the session to use the given keyspace."
+  [^Session session ks-name]
+  (execute! session (str "USE " ks-name)))
+
+;; ---- Timeout execution ----
+
+(defn execute-with-timeout!
+  "Executes a CQL string with a custom read timeout in milliseconds."
+  [^Session session timeout ^String cql]
+  (let [stmt (doto (SimpleStatement. cql)
+               (.setReadTimeoutMillis (int timeout)))]
+    (resultset->maps (.execute session stmt))))
+
+;; ---- CQL builders: CREATE TABLE ----
+
+(defn build-create-table
+  "Builds a CREATE TABLE IF NOT EXISTS CQL string. col-defs is a map like
+  {:id :int, :balance :bigint, :primary-key [:id]}."
+  [table col-defs]
+  (let [pk       (:primary-key col-defs)
+        cols     (dissoc col-defs :primary-key)
+        col-strs (map (fn [[col-name col-type]]
+                        (str (name col-name) " " (name col-type)))
+                      cols)
+        pk-str   (str "PRIMARY KEY (" (str/join ", " (map name pk)) ")")]
+    (str "CREATE TABLE IF NOT EXISTS " table
+         " (" (str/join ", " (concat col-strs [pk-str])) ")")))
+
+(defn create-table
+  "Creates a table with a 30s timeout. col-defs is a map like
+  {:id :int, :balance :bigint, :primary-key [:id]}."
+  [session table col-defs]
+  (execute-with-timeout! session 30000 (build-create-table table col-defs)))
+
+(defn create-transactional-table
+  "Like create-table, but enables YugaByte transactions."
+  [session table col-defs]
+  (execute-with-timeout! session 30000
+                         (str (build-create-table table col-defs)
+                              " WITH transactions = { 'enabled' : true }")))
+
+(defn create-index
+  "Creates an index with a 30s timeout. Takes a raw CQL string.
+  Swallows 'already exists' errors."
+  [session cql]
+  (try (execute-with-timeout! session 30000 cql)
+       (catch InvalidQueryException e
+         (if (re-find #"already exists" (.getMessage e))
+           :already-exists
+           (throw e)))))
+
+;; ---- CRUD ----
+
+(defn select
+  "Executes a SELECT query. Options:
+    :keyspace  - qualify table with keyspace
+    :columns   - vector of column keywords (default *)
+    :where     - vector of condition vectors"
+  [session table & {:keys [keyspace columns where]}]
+  (let [table-ref (if keyspace (str keyspace "." table) table)
+        cols      (if columns
+                    (str/join ", " (map name columns))
+                    "*")
+        cql       (str "SELECT " cols " FROM " table-ref
+                       (when where
+                         (str " WHERE " (format-conditions where))))]
+    (execute! session cql)))
+
+(defn insert!
+  "Executes an INSERT query. values is a map of column/value pairs."
+  [session table values & {:keys [keyspace]}]
+  (let [table-ref (if keyspace (str keyspace "." table) table)
+        entries   (seq values)
+        cols      (str/join ", " (map (comp name key) entries))
+        vals      (str/join ", " (map (comp format-value val) entries))]
+    (execute! session (str "INSERT INTO " table-ref
+                           " (" cols ") VALUES (" vals ")"))))
+
+(defn update!
+  "Executes an UPDATE query. set-map is a map of column/value pairs to SET.
+  Options:
+    :keyspace  - qualify table with keyspace
+    :where     - vector of condition vectors
+    :only-if   - vector of condition vectors for lightweight transactions"
+  [session table set-map & {:keys [keyspace where only-if]}]
+  (let [table-ref (if keyspace (str keyspace "." table) table)
+        set-str   (str/join ", " (map (fn [[col v]]
+                                        (str (name col) " = " (format-value v)))
+                                      set-map))]
+    (execute! session (str "UPDATE " table-ref
+                           " SET " set-str
+                           (when where
+                             (str " WHERE " (format-conditions where)))
+                           (when only-if
+                             (str " IF " (format-conditions only-if)))))))
+
+(defn update-counter!
+  "Executes an UPDATE for a counter column. Uses col = col + amount syntax."
+  [session table col amount & {:keys [keyspace where]}]
+  (let [table-ref (if keyspace (str keyspace "." table) table)
+        col-name  (name col)]
+    (execute! session (str "UPDATE " table-ref
+                           " SET " col-name " = " col-name " + " amount
+                           (when where
+                             (str " WHERE " (format-conditions where)))))))
+
+;; ---- Retry helper ----
 
 (defmacro with-retry
   "Retries CQL unavailable/timeout errors for up to 120 seconds. Helpful for
@@ -57,6 +236,8 @@
                (Thread/sleep (long (random/long sleep#)))
                (~'retry)))))))
 
+;; ---- Cluster & connect ----
+
 (defn epoll-event-loop-group-constructor
   "Why is this not public?"
   []
@@ -71,9 +252,7 @@
   (boolean (wh/method NettyUtil :isEpollAvailable [] nil)))
 
 (defn ^Cluster cluster
-  "Constructs a Cassandra client Cluster object with appropriate options.
-  Normally we'd let Cassaforte do this, but we need to reach into its guts to
-  pass some options, like ThreadingOptions, Cassaforte doesn't support."
+  "Constructs a Cassandra client Cluster object with appropriate options."
   [node]
   (.. (Cluster/builder)
     (withProtocolVersion (ProtocolVersion/fromInt 3))
@@ -83,8 +262,8 @@
     ; This is sort of a hack; we're allowed to call cn/ip here without an SSH
     ; connection because it memoizes, and we already called it during setup.
     (addContactPoint (cn/ip node))
-    (withRetryPolicy (policies/retry-policy :no-retry-on-client-timeout))
-    (withReconnectionPolicy (policies/constant-reconnection-policy 1000))
+    (withRetryPolicy NoRetryOnClientTimeoutPolicy/INSTANCE)
+    (withReconnectionPolicy (ConstantReconnectionPolicy. 1000))
     (withSocketOptions (.. (SocketOptions.)
                          (setConnectTimeoutMillis 1000)
                          (setReadTimeoutMillis 5000)))
@@ -112,86 +291,24 @@
     (build)))
 
 (defn connect
-  "Opens a new client, with helpful defaults for YugaByte. Options are passed to
-  Cassaforte."
-  ([node]
-   (connect node {}))
-  ([node opts]
-   (with-retry
-     (let [c (cluster node)]
-       (try (.connect c)
-            (catch DriverException e
-              (.close c)
-              (throw e)))))))
-
-(defn execute-with-timeout!
-  "Executes a statement on a session, but applies a custom read timeout, in
-  milliseconds, for it."
-  [session timeout statement]
-  (let [statement (.. (c/build-statement statement)
-                      (setReadTimeoutMillis timeout))]
-    (c/execute session statement)))
-
-(defn statement->str
-  "Converts a statement to a string so we can do string munging on it."
-  [s]
-  (if (string? s)
-    s
-    (-> s
-        ;(.setForceNoValues true)
-        .getQueryString)))
-
-(defn with-transactions
-  "Takes a CQL create-table statement, converts it to a string, and adds \"WITH
-  transctions = { 'enabled' : true }\". Sort of a hack, the Cassandra client
-  doesn't know about this syntax, I think."
-  [s]
-  (str (statement->str s) " WITH transactions = { 'enabled' : true }"))
-
-(defn create-table
-  "Table creation is fairly slow in YB, so we need to run it with a custom
-  timeout. Works just like cql/create-table."
-  [conn & table-args]
-  (execute-with-timeout! conn 30000 (apply q/create-table table-args)))
-
-(defn create-index
-  "Index creation is also slow in YB, so we run it with a custom timeout. Works
-  just like cql/create-index, or you can pass a string if you need to use YB
-  custom syntax.
-
-  Also you, like, literally *can't* tell Cassaforte (or maybe Cassandra's
-  client or CQL or YB?) to create an index if it doesn't exist, so we're
-  swallowing the duplicate table execeptions here.
-  TODO: update YB Cassaforte fork, so we can use `CREATE INDEX IF NOT EXISTS`.
-  "
-  [conn & index-args]
-  (let [statement (if (and (= 1 (count index-args))
-                           (string? (first index-args)))
-                    (first index-args)
-                    (apply q/create-index index-args))]
-    (try (execute-with-timeout! conn 30000 statement)
-         (catch InvalidQueryException e
-           (if (re-find #"already exists" (.getMessage e))
-             :already-exists
+  "Opens a new client, with helpful defaults for YugaByte."
+  [node]
+  (with-retry
+    (let [c (cluster node)]
+      (try (.connect c)
+           (catch DriverException e
+             (.close c)
              (throw e))))))
 
-(defn create-transactional-table
-  "Like create-table, but enables transactions."
-  [conn & table-args]
-  (execute-with-timeout! conn 30000
-                         (with-transactions
-                           (apply q/create-table table-args))))
+;; ---- Keyspace setup ----
 
 (defn ensure-keyspace!
   "Creates a keyspace using the given connection, if it doesn't already exist.
   Replication-factor is derived from the test."
   [conn keyspace-name test]
-  (cql/create-keyspace conn keyspace-name
-                       (q/if-not-exists)
-                       (q/with {:replication
-                                {"class" "SimpleStrategy"
-                                 "replication_factor"
-                                 (:replication-factor test)}})))
+  (create-keyspace! conn keyspace-name (:replication-factor test)))
+
+;; ---- Error handling ----
 
 (defmacro with-errors
   "Takes an op, a set of idempotent operation :fs, and a body. Evalates body,
@@ -241,6 +358,8 @@
          (if (re-find #"RPC to .+ timed out after " (.getMessage e#))
            (assoc ~op :type crash#, :error [:rpc-timed-out (.getMessage e#)])
            (throw e#))))))
+
+;; ---- Client macro ----
 
 (defmacro defclient
   "Helper for defining CQL clients. Takes a class name, a string keyspace, a
@@ -293,18 +412,18 @@
            (open! [~'this ~'test ~'node]
              (let [conn# (connect ~'node)]
                (when (realized? ~'keyspace-created)
-                 (cql/use-keyspace conn# ~keyspace))
+                 (use-keyspace! conn# ~keyspace))
                (assoc ~'this :conn conn#)))
 
            (setup! [~'this ~'test]
              (locking ~'keyspace-created
                (ensure-keyspace! ~'conn ~keyspace ~'test)
                (deliver ~'keyspace-created true)
-               (cql/use-keyspace ~'conn ~keyspace)
+               (use-keyspace! ~'conn ~keyspace)
                ~@setup-code))
 
            (close! [~'this ~'test]
-             (c/disconnect! ~'conn))
+             (disconnect! ~'conn))
 
            ~@exprs)
 
@@ -313,6 +432,8 @@
            ~(vec fields)
            ; Pass user fields, conn, keyspace-created
            (new ~name ~@fields nil (promise))))))
+
+;; ---- Await setup ----
 
 (defn await-setup
   "Used at the start of a test. Takes a node, opens a connection to it, and
@@ -335,12 +456,7 @@
           (locking await-setup
             ; This... doesn't actually seem to guarantee that subsequent
             ; attempts to create keyspaces, tables, and rows will work. Grrr.
-            (cql/create-keyspace conn "jepsen_setup"
-                                 (q/if-not-exists)
-                                 (q/with
-                                   {:replication
-                                    {"class"              "SimpleStrategy"
-                                     "replication_factor" 3}}))
+            (create-keyspace! conn "jepsen_setup" 3)
 
             (execute-with-timeout!
               conn 10000
@@ -348,12 +464,12 @@
                    " (id INT PRIMARY KEY, balance BIGINT)"
                    " WITH transactions = { 'enabled': true }"))
 
-            (cql/insert-with-ks conn "jepsen_setup" "waiting"
-                                {:id 0, :balance 5}))
+            (insert! conn "waiting" {:id 0, :balance 5}
+                     :keyspace "jepsen_setup"))
           (info "Cluster ready")
 
           (finally
-            (c/disconnect! conn))))
+            (disconnect! conn))))
 
       (catch com.datastax.driver.core.exceptions.InvalidQueryException e
         (condp re-find (.getMessage e)

--- a/yugabyte/src/yugabyte/ycql/client.clj
+++ b/yugabyte/src/yugabyte/ycql/client.clj
@@ -5,7 +5,8 @@
                                      [policies :as policies]
                                      [cql :as cql]]
             [clojure.tools.logging :refer [info]]
-            [jepsen [util :as util]]
+            [jepsen [random :as random]
+                    [util :as util]]
             [jepsen.control.net :as cn]
             [dom-top.core :as dt]
             [wall.hack :as wh])
@@ -47,13 +48,13 @@
          (if (< deadline# (util/linear-time-nanos))
            (throw e#)
            (do (info "Timed out, retrying")
-               (Thread/sleep (long (rand-int sleep#)))
+               (Thread/sleep (long (random/long sleep#)))
                (~'retry))))
        (catch OperationTimedOutException e#
          (if (< deadline# (util/linear-time-nanos))
            (throw e#)
            (do (info "Timed out, retrying")
-               (Thread/sleep (long (rand-int sleep#)))
+               (Thread/sleep (long (random/long sleep#)))
                (~'retry)))))))
 
 (defn epoll-event-loop-group-constructor

--- a/yugabyte/src/yugabyte/ycql/counter.clj
+++ b/yugabyte/src/yugabyte/ycql/counter.clj
@@ -1,37 +1,33 @@
 (ns yugabyte.ycql.counter
   (:require [clojure.tools.logging :refer [debug info warn]]
             [jepsen.client :as client]
-            [clojurewerkz.cassaforte.client :as cassandra]
-            [clojurewerkz.cassaforte.query :refer :all]
-            [clojurewerkz.cassaforte.policies :refer :all]
-            [clojurewerkz.cassaforte.cql :as cql]
             [yugabyte.ycql.client :as c]))
 
 (def table-name "counter")
 (def keyspace "jepsen")
 
 (c/defclient CQLCounterClient keyspace []
-             (setup! [this test]
-                     (c/create-table conn table-name
-                                     (if-not-exists)
-                                     (column-definitions {:id          :int
-                                                          :count       :counter
-                                                          :primary-key [:id]}))
-                     (cql/update conn table-name {:count (increment-by 0)}
-                                 (where [[= :id 0]])))
+  (setup! [this test]
+    (c/create-table conn table-name
+                    {:id          :int
+                     :count       :counter
+                     :primary-key [:id]})
+    (c/update-counter! conn table-name :count 0
+                       :where [[:= :id 0]]))
 
-             (invoke! [this test op]
-                      (c/with-errors op #{:read}
-                                     (case (:f op)
-                                       :add (do (cql/update-with-ks conn keyspace table-name
-                                                                    {:count (increment-by (:value op))}
-                                                                    (where [[= :id 0]]))
-                                                (assoc op :type :ok))
+  (invoke! [this test op]
+    (c/with-errors op #{:read}
+      (case (:f op)
+        :add (do (c/update-counter! conn table-name :count (:value op)
+                                    :keyspace keyspace
+                                    :where [[:= :id 0]])
+                 (assoc op :type :ok))
 
-                                       :read (let [value (->> (cql/select-with-ks conn keyspace table-name
-                                                                                  (where [[= :id 0]]))
-                                                              first
-                                                              :count)]
-                                               (assoc op :type :ok :value value)))))
+        :read (let [value (->> (c/select conn table-name
+                                         :keyspace keyspace
+                                         :where [[:= :id 0]])
+                               first
+                               :count)]
+                (assoc op :type :ok :value value)))))
 
-             (teardown! [this test]))
+  (teardown! [this test]))

--- a/yugabyte/src/yugabyte/ycql/long_fork.clj
+++ b/yugabyte/src/yugabyte/ycql/long_fork.clj
@@ -1,8 +1,6 @@
 (ns yugabyte.ycql.long-fork
   (:refer-clojure :exclude [test])
-  (:require [clojurewerkz.cassaforte.cql :as cql]
-            [clojurewerkz.cassaforte.query :as q]
-            [jepsen.tests.long-fork :as lf]
+  (:require [jepsen.tests.long-fork :as lf]
             [yugabyte.ycql.client :as c]))
 
 (def keyspace "jepsen")
@@ -12,16 +10,12 @@
   (setup! [this test]
     (c/create-transactional-table
       conn table
-      (q/if-not-exists)
-      (q/column-definitions {:key   :int
-                             :key2  :int
-                             :val   :int
-                             :primary-key [:key]}))
-    (c/create-index conn (str (c/statement->str
-                                (q/create-index "long_forks"
-                                                (q/on-table table)
-                                                (q/and-column :key2)))
-                              " INCLUDE (val)")))
+      {:key   :int
+       :key2  :int
+       :val   :int
+       :primary-key [:key]})
+    (c/create-index conn
+      "CREATE INDEX IF NOT EXISTS long_forks ON long_fork (key2) INCLUDE (val)"))
 
   (invoke! [this test op]
     (let [txn (:value op)]
@@ -29,9 +23,9 @@
         (case (:f op)
           :read (let [ks (seq (lf/op-read-keys op))
                       ; Look up values by the value index
-                      vs (->> (cql/select conn table
-                                          (q/columns :key2 :val)
-                                          (q/where [[:in :key2 ks]]))
+                      vs (->> (c/select conn table
+                                        :columns [:key2 :val]
+                                        :where [[:in :key2 ks]])
                               (map (juxt :key2 :val))
                               (into (sorted-map)))
                       ; Rewrite txn to use those values
@@ -43,10 +37,10 @@
                   (assoc op :type :ok :value txn'))
 
           :write (let [[[_ k v]] txn]
-                   (do (cql/insert conn table
-                                   {:key k
-                                    :key2 k
-                                    :val v})
+                   (do (c/insert! conn table
+                                  {:key k
+                                   :key2 k
+                                   :val v})
                        (assoc op :type :ok)))))))
 
   (teardown! [this test]))

--- a/yugabyte/src/yugabyte/ycql/multi_key_acid.clj
+++ b/yugabyte/src/yugabyte/ycql/multi_key_acid.clj
@@ -1,9 +1,7 @@
 (ns yugabyte.ycql.multi-key-acid
   (:require [jepsen.independent :as independent]
             [jepsen.txn.micro-op :as mop]
-            [clojurewerkz.cassaforte.client :as cassandra]
-            [clojurewerkz.cassaforte.query :as q :refer :all]
-            [clojurewerkz.cassaforte.cql :as cql]
+            [clojure.string :as str]
             [yugabyte.ycql.client :as c]))
 
 (def table-name "multi_key_acid")
@@ -13,11 +11,10 @@
   (setup! [this test]
     (c/create-transactional-table
       conn table-name
-      (q/if-not-exists)
-      (q/column-definitions {:id          :int
-                             :ik          :int
-                             :val         :int
-                             :primary-key [:id :ik]})))
+      {:id          :int
+       :ik          :int
+       :val         :int
+       :primary-key [:id :ik]}))
 
   (invoke! [this test op]
     (c/with-errors op #{:read}
@@ -26,10 +23,10 @@
           :read
           (let [ks (map mop/key txn)
                 ; Look up values
-                vs (->> (cql/select conn table-name
-                                    (q/columns :id :val)
-                                    (q/where [[= :ik ik]
-                                              [:in :id ks]]))
+                vs (->> (c/select conn table-name
+                                  :columns [:id :val]
+                                  :where [[:= :ik ik]
+                                          [:in :id ks]])
                         (map (juxt :id :val))
                         (into {}))
                 ; Rewrite txn to use those values
@@ -37,25 +34,18 @@
             (assoc op :type :ok, :value (independent/tuple ik txn')))
 
           :write
-          ; TODO - temporarily replaced by single DB call until YugaByteDB
-          ; supports transaction spanning multiple DB calls.
-          ;                 (cassandra/execute conn "BEGIN TRANSACTION")
-          ;                 (doseq [[sub-op id val] value]
-          ;                   (assert (= sub-op :write))
-          ;                   (cql/insert conn table-name {:id id :val val}))
-          ;                 (cassandra/execute conn "END TRANSACTION;")
-          (do (cassandra/execute conn
-                                 (str "BEGIN TRANSACTION "
-                                      (->> (for [[f k v] txn]
-                                             (do
-                                               ; We only support writes
-                                               (assert (= :w f))
-                                               (str "INSERT INTO "
-                                                    keyspace "." table-name
-                                                    " (id, ik, val) VALUES ("
-                                                    k ", " ik ", " v ");")))
-                                           clojure.string/join)
-                                      "END TRANSACTION;"))
+          (do (c/execute! conn
+                          (str "BEGIN TRANSACTION "
+                               (->> (for [[f k v] txn]
+                                      (do
+                                        ; We only support writes
+                                        (assert (= :w f))
+                                        (str "INSERT INTO "
+                                             keyspace "." table-name
+                                             " (id, ik, val) VALUES ("
+                                             k ", " ik ", " v ");")))
+                                    str/join)
+                               "END TRANSACTION;"))
               (assoc op :type :ok))))))
 
   (teardown! [this test]))

--- a/yugabyte/src/yugabyte/ycql/set.clj
+++ b/yugabyte/src/yugabyte/ycql/set.clj
@@ -1,69 +1,60 @@
 (ns yugabyte.ycql.set
-  (:require [clojurewerkz.cassaforte.query :as q]
-            [clojurewerkz.cassaforte.cql :as cql]
-            [jepsen.random :as random]
+  (:require [jepsen.random :as random]
             [yugabyte.ycql.client :as c]))
 
 (def keyspace "jepsen")
 (def table "elements")
 
 (c/defclient CQLSetClient keyspace []
-             (setup! [this test]
-                     (c/create-table conn table
-                                     (q/if-not-exists)
-                                     (q/column-definitions {:val         :int
-                                                            :count       :counter
-                                                            :primary-key [:val]})))
+  (setup! [this test]
+    (c/create-table conn table
+                    {:val         :int
+                     :count       :counter
+                     :primary-key [:val]}))
 
-             (invoke! [this test op]
-                      (c/with-errors op #{:read}
-                                     (case (:f op)
-                                       :add (do (cql/update conn table
-                                                            {:count (q/increment)}
-                                                            (q/where {:val (:value op)}))
-                                                (assoc op :type :ok))
+  (invoke! [this test op]
+    (c/with-errors op #{:read}
+      (case (:f op)
+        :add (do (c/update-counter! conn table :count 1
+                                    :where [[:= :val (:value op)]])
+                 (assoc op :type :ok))
 
-                                       :read (->> (cql/select-with-ks conn keyspace table)
-                                                  (mapcat (fn [row]
-                                                            (repeat (:count row) (:val row))))
-                                                  sort
-                                                  (assoc op :type :ok, :value)))))
+        :read (->> (c/select conn table :keyspace keyspace)
+                   (mapcat (fn [row]
+                             (repeat (:count row) (:val row))))
+                   sort
+                   (assoc op :type :ok, :value)))))
 
-             (teardown! [this test]))
+  (teardown! [this test]))
 
 (def group-count
   "Number of distinct groups for indexing"
   8)
 
 (c/defclient CQLSetIndexClient keyspace []
-             (setup! [this test]
-                     (c/create-transactional-table conn table
-                                                   (q/if-not-exists)
-                                                   (q/column-definitions
-                                                     {:key         :int
-                                                      :val         :int
-                                                      :grp         :int
-                                                      :primary-key [:key]}))
-                     (c/create-index conn (str (c/statement->str
-                                                 (q/create-index "elements_by_group"
-                                                                 (q/on-table table)
-                                                                 (q/and-column :grp)))
-                                               " INCLUDE (val)")))
+  (setup! [this test]
+    (c/create-transactional-table conn table
+                                  {:key         :int
+                                   :val         :int
+                                   :grp         :int
+                                   :primary-key [:key]})
+    (c/create-index conn
+      "CREATE INDEX IF NOT EXISTS elements_by_group ON elements (grp) INCLUDE (val)"))
 
-             (invoke! [this test op]
-                      (c/with-errors op #{:read}
-                                     (case (:f op)
-                                       :add (do (cql/insert conn table
-                                                            {:key (:value op)
-                                                             :val (:value op)
-                                                             :grp (random/long group-count)})
-                                                (assoc op :type :ok))
+  (invoke! [this test op]
+    (c/with-errors op #{:read}
+      (case (:f op)
+        :add (do (c/insert! conn table
+                            {:key (:value op)
+                             :val (:value op)
+                             :grp (random/long group-count)})
+                 (assoc op :type :ok))
 
-                                       :read (->> (cql/select conn table
-                                                              (q/columns :val)
-                                                              (q/where [[:in :grp (range group-count)]]))
-                                                  (map :val)
-                                                  sort
-                                                  (assoc op :type :ok, :value)))))
+        :read (->> (c/select conn table
+                             :columns [:val]
+                             :where [[:in :grp (range group-count)]])
+                   (map :val)
+                   sort
+                   (assoc op :type :ok, :value)))))
 
-             (teardown! [this test]))
+  (teardown! [this test]))

--- a/yugabyte/src/yugabyte/ycql/set.clj
+++ b/yugabyte/src/yugabyte/ycql/set.clj
@@ -1,6 +1,7 @@
 (ns yugabyte.ycql.set
   (:require [clojurewerkz.cassaforte.query :as q]
             [clojurewerkz.cassaforte.cql :as cql]
+            [jepsen.random :as random]
             [yugabyte.ycql.client :as c]))
 
 (def keyspace "jepsen")
@@ -55,7 +56,7 @@
                                        :add (do (cql/insert conn table
                                                             {:key (:value op)
                                                              :val (:value op)
-                                                             :grp (rand-int group-count)})
+                                                             :grp (random/long group-count)})
                                                 (assoc op :type :ok))
 
                                        :read (->> (cql/select conn table

--- a/yugabyte/src/yugabyte/ycql/single_key_acid.clj
+++ b/yugabyte/src/yugabyte/ycql/single_key_acid.clj
@@ -1,9 +1,6 @@
 (ns yugabyte.ycql.single-key-acid
   (:require [clojure [pprint :refer :all]]
             [jepsen.independent :as independent]
-            [clojurewerkz.cassaforte.query :refer :all]
-            [clojurewerkz.cassaforte.policies :refer :all]
-            [clojurewerkz.cassaforte.cql :as cql]
             [yugabyte.ycql.client :as c]))
 
 (def keyspace "jepsen")
@@ -12,32 +9,34 @@
 (c/defclient CQLSingleKey keyspace []
   (setup! [this test]
     (c/create-table conn table-name
-                    (if-not-exists)
-                    (column-definitions {:id :int
-                                         :val :int
-                                         :primary-key [:id]})))
+                    {:id  :int
+                     :val :int
+                     :primary-key [:id]}))
 
   (invoke! [this test op]
     (c/with-errors op #{:read}
       (let [[id val] (:value op)]
         (case (:f op)
           :write
-          (do (cql/insert-with-ks conn keyspace table-name
-                                  {:id id, :val val})
+          (do (c/insert! conn table-name
+                         {:id id, :val val}
+                         :keyspace keyspace)
               (assoc op :type :ok))
 
           :cas
           (let [[expected-val new-val] val
-                res (cql/update-with-ks conn keyspace table-name
-                                        {:val new-val}
-                                        (only-if [[= :val expected-val]])
-                                        (where [[= :id id]]))
+                res (c/update! conn table-name
+                               {:val new-val}
+                               :keyspace keyspace
+                               :where [[:= :id id]]
+                               :only-if [[:= :val expected-val]])
                 applied (get (first res) (keyword "[applied]"))]
             (assoc op :type (if applied :ok :fail)))
 
           :read
-          (let [value (->> (cql/select-with-ks conn keyspace table-name
-                                               (where [[= :id id]]))
+          (let [value (->> (c/select conn table-name
+                                     :keyspace keyspace
+                                     :where [[:= :id id]])
                            first
                            :val)]
             (assoc op :type :ok :value (independent/tuple id value)))))))

--- a/yugabyte/src/yugabyte/ysql/append.clj
+++ b/yugabyte/src/yugabyte/ysql/append.clj
@@ -7,6 +7,7 @@
   (:require [clojure.string :as str]
             [clojure.java.jdbc :as j]
             [clojure.tools.logging :refer [info]]
+            [jepsen.random :as random]
             [yugabyte.auto :as a]
             [yugabyte.ysql.client :as c]))
 
@@ -40,7 +41,7 @@
 (defn select-with-optional-lock
   [locking col table]
   (let [clause (if (= :pessimistic locking)
-                 (rand-nth ["" " for update" " for no key update" " for share" " for key share"])
+                 (random/nth ["" " for update" " for no key update" " for share" " for key share"])
                  "")]
     (str "select (" col ") from " table " where k = ?" clause)))
 
@@ -89,7 +90,7 @@
             (do
               ; Randomly evaluate SELECT FOR UPDATE with timeout in case of pessimistic locking
               (c/query conn [(select-with-optional-lock locking col table) row])
-              (Thread/sleep (long (rand-int 2000))))
+              (Thread/sleep (long (random/long 2000))))
             nil)
         r (c/execute! conn [(str "update " table
                                  " set " col " = CONCAT(" col ", ',', ?)"

--- a/yugabyte/src/yugabyte/ysql/bank.clj
+++ b/yugabyte/src/yugabyte/ysql/bank.clj
@@ -1,6 +1,7 @@
 (ns yugabyte.ysql.bank
   (:require [clojure.java.jdbc :as j]
             [clojure.tools.logging :refer [debug info warn]]
+            [jepsen.random :as random]
             [yugabyte.ysql.client :as c]))
 
 (def table-name "accounts")
@@ -87,7 +88,7 @@
     (case (:f op)
       :read
       (j/with-db-transaction [c c {:isolation isolation}]
-        (let [accs (shuffle (:accounts test))]
+        (let [accs (random/shuffle (:accounts test))]
           (->> accs
                (mapv (fn [a]
                        (c/select-single-value op c (str table-name a) :balance (str "id = " a))))

--- a/yugabyte/src/yugabyte/ysql/client.clj
+++ b/yugabyte/src/yugabyte/ysql/client.clj
@@ -4,6 +4,7 @@
             [clojure.pprint :refer [pprint]]
             [clojure.string :as str]
             [clojure.tools.logging :refer [info warn]]
+            [jepsen.random :as random]
             [jepsen.util :as util]
             [jepsen.control.net :as cn]
             [jepsen.client :as client]
@@ -319,7 +320,7 @@
                  (re-find #"A relation has an associated type of the same name" m#)
                  (re-find #"Operation expired: Transaction expired" m#))
            (do (info "Caught" m# "during DDL setup; retrying.")
-               (Thread/sleep (long (rand-int max-delay-between-retries-ms)))
+               (Thread/sleep (long (random/long max-delay-between-retries-ms)))
                (~'retry (dec attempts#)))
            (throw e#))))))
 
@@ -352,7 +353,7 @@
                     (catch java.sql.SQLException e#
                       (if (and (pos? attempts#)
                                (retryable? e#))
-                        (do (Thread/sleep (long (rand-int max-delay-between-retries-ms)))
+                        (do (Thread/sleep (long (random/long max-delay-between-retries-ms)))
                             (~'retry (dec attempts#)))
                         (throw e#)))))
 

--- a/yugabyte/src/yugabyte/ysql/set.clj
+++ b/yugabyte/src/yugabyte/ysql/set.clj
@@ -1,5 +1,6 @@
 (ns yugabyte.ysql.set
   (:require [clojure.java.jdbc :as j]
+            [jepsen.random :as random]
             [yugabyte.ysql.client :as c]))
 
 (def table-name "elements")
@@ -63,7 +64,7 @@
     (case (:f op)
       :add (do (c/insert! op c table-name {:id  (:value op)
                                            :val (:value op)
-                                           :grp (rand-int group-count)})
+                                           :grp (random/long group-count)})
                (assoc op :type :ok))
 
       :read (let [value (->> set-index-query


### PR DESCRIPTION
Summary
                                                                                                                                                                                                                                                             
  This PR introduces deterministic test reproducibility via random seeds and migrates the YCQL client layer from Cassaforte to the DataStax Java Cassandra driver.

  Deterministic randomness

  - Add --random-seed SEED CLI option for reproducible test execution
  - Wrap test construction and execution with jepsen.random/with-seed, persist seed in the test map as :random-seed (stored in results.edn)
  - Replace all rand-int, rand-nth, rand, and shuffle calls with jepsen.random equivalents (random/long, random/nth, random/bool, random/shuffle) across workloads: bank-improved, single-key-acid, multi-key-acid, YCQL client, and core
  - Custom single-test-cmd replaces cli/single-test-cmd to integrate seed handling into both test and test-all subcommands

  Cassaforte → DataStax Java driver migration

  - Remove cassaforte dependency, add com.yugabyte/cassandra-driver-core "3.10.3-yb-3" and explicit slf4j-api "2.0.17"
  - Rewrite yugabyte.ycql.client to use the DataStax driver directly: new CQL builder functions (create-table, create-transactional-table, select, insert!, update!, update-counter!, create-index), ResultSet → Clojure maps conversion, and direct
  Session/Cluster management
  - Update all YCQL workloads (bank, bank-improved, counter, set, long-fork, single-key-acid, multi-key-acid) to use the new client API instead of Cassaforte's cql/ and q/ namespaces
  - Use NoRetryOnClientTimeoutPolicy/INSTANCE and ConstantReconnectionPolicy directly instead of Cassaforte policy wrappers

  Other improvements

  - Upgrade Jepsen dependency from 0.3.7 to 0.3.10
  - Increase default concurrency from 4n to 6n in run-jepsen.py
  - Set JAVA_HOME to /usr/lib/jvm/zulu-17.jdk and log Java version in the Python runner
  - Replace cu/ls with cu/exists? for post-install script assertion
  - Use cu/ls {:full-path? true} instead of cu/ls-full for log file collection
