### PR TITLE
Skip append-table tests on 2026.1 due to disabled Concurrent DDLs feature

### DIFF
--- a/yugabyte/run-jepsen.py
+++ b/yugabyte/run-jepsen.py
@@ -156,7 +156,8 @@ TEST_PER_VERSION = [
     },
     {
         "start_version": "2.29.0.0-b500",
-        "start_version_stable": "2026.1.0.0-b1",
+        # Skip append-table tests for 2026.1
+        "start_version_stable": "2026.2.0.0-b1",
         "tests": [
             "ysql/sz.append-table",
             "ysql/si.append-table",


### PR DESCRIPTION
The append-table tests are failing on 2026.1 branch due to Concurrent DDLs feature not being enabled on the branch.