### PR TITLE
Add si.queue/rc.queue Jepsen workloads for SELECT ... FOR UPDATE SKIP LOCKED

### DIFF
--- a/yugabyte/run-jepsen.py
+++ b/yugabyte/run-jepsen.py
@@ -180,6 +180,8 @@ TEST_PER_VERSION = [
         #   monotonic - per-session monotonic reads
         #   g2        - Adya predicate write-skew (serializable only)
         #   long-fork - snapshot-isolation long-fork anomaly (also at si)
+        #   queue     - SELECT ... FOR UPDATE SKIP LOCKED work queue (no sz:
+        #               SKIP LOCKED downgrades to blocking there, #11761)
         "start_version": "2.20.0.0-b1",
         "tests": [
             "ysql/rc.wr",
@@ -190,6 +192,8 @@ TEST_PER_VERSION = [
             "ysql/si.types",
             "ysql/rc.monotonic",
             "ysql/si.monotonic",
+            "ysql/rc.queue",
+            "ysql/si.queue",
             "ysql/sz.g2",
             "ysql/si.long-fork",
             "ycql/upsert",

--- a/yugabyte/src/yugabyte/core.clj
+++ b/yugabyte/src/yugabyte/core.clj
@@ -14,7 +14,8 @@
              [upsert :as upsert]
              [types :as types]
              [g2 :as g2]
-             [monotonic :as monotonic]]
+             [monotonic :as monotonic]
+             [queue :as queue]]
             [yugabyte.auto :as auto]
             [yugabyte.bank :as bank]
             [yugabyte.bank-improved :as bank-improved]
@@ -43,7 +44,8 @@
              [upsert :as ysql.upsert]
              [types :as ysql.types]
              [g2 :as ysql.g2]
-             [monotonic :as ysql.monotonic]]
+             [monotonic :as ysql.monotonic]
+             [queue :as ysql.queue]]
             [yugabyte.ysql.bank]
             [yugabyte.ysql.bank-improved]
             [yugabyte.ysql.counter]
@@ -166,7 +168,13 @@
 
          ; Per-session monotonic reads over a monotonically increasing register.
          :si.monotonic       (with-client monotonic/workload (ysql.monotonic/->Client :repeatable-read))
-         :rc.monotonic       (with-client monotonic/workload (ysql.monotonic/->Client :read-committed))})
+         :rc.monotonic       (with-client monotonic/workload (ysql.monotonic/->Client :read-committed))
+
+         ; SELECT ... FOR UPDATE SKIP LOCKED work queue: no payload claimed twice,
+         ; nothing left unclaimed once drained. No sz. variant - YugabyteDB
+         ; downgrades SKIP LOCKED to blocking at serializable (yugabyte-db#11761).
+         :si.queue           (with-client queue/workload (ysql.queue/->Client :repeatable-read))
+         :rc.queue           (with-client queue/workload (ysql.queue/->Client :read-committed))})
 
 (def workloads
   (merge workloads-ycql workloads-ysql))

--- a/yugabyte/src/yugabyte/generator.clj
+++ b/yugabyte/src/yugabyte/generator.clj
@@ -3,12 +3,17 @@
 
 (defn with-op-index
   "Append :op-index integer to every operation emitted by the given generator.
-  Value starts at 1 and increments by 1 for every subsequent emitted operation."
-  [gen]
-  (let [ctr (atom 0)]
-    (gen/map (fn add-op-index [op]
-               (assoc op :op-index (swap! ctr inc)))
-             gen)))
+  Value starts at 1 and increments by 1 for every subsequent emitted operation.
+  Pass an explicit counter atom to share one numbering across several
+  generators, e.g. a workload's main and final generators - each generator
+  getting its own counter would restart at 1 and make the indices ambiguous in
+  server-side logs."
+  ([gen]
+   (with-op-index (atom 0) gen))
+  ([ctr gen]
+   (gen/map (fn add-op-index [op]
+              (assoc op :op-index (swap! ctr inc)))
+            gen)))
 
 (defn workload-with-op-index
   "Alters a workload map, wrapping generator in with-op-index"

--- a/yugabyte/src/yugabyte/queue.clj
+++ b/yugabyte/src/yugabyte/queue.clj
@@ -1,0 +1,222 @@
+(ns yugabyte.queue
+  "Work-queue workload for SELECT ... FOR UPDATE SKIP LOCKED, YugabyteDB's
+  documented job-queue primitive: a claimer takes the first unlocked matching row
+  and skips rows another transaction holds, instead of blocking.
+
+    :enqueue v  -> insert a row with a globally unique, increasing payload.
+    :dequeue    -> claim the head of the queue. :ok with the claimed payload, or
+                   :fail :empty when nothing was claimable, which is a legal
+                   outcome and never an anomaly by itself. Ops marked
+                   :drain? true are the final phase's hold-free drain.
+    :read-table -> every row: the checker's ground truth, since a checker sees
+                   only the history, never the database.
+
+  Invariants: no payload is claimed twice (mutual exclusion, checked always), and
+  every acked enqueue is still present and eventually claimed (completeness,
+  asserted only once the drain has quiesced, because YugabyteDB also skips rows a
+  committed transaction touched after the reader's read time, so mid-run a row can
+  be briefly invisible to every claimer). Indeterminate claims are budgeted rather
+  than assumed either way.
+
+  Bespoke rather than jepsen.checker/total-queue: that checker does not fail on
+  duplicates, and its drain handling throws on the :info ops a nemesis produces.
+
+  No sz. variant: YugabyteDB downgrades SKIP LOCKED to a blocking lock at
+  serializable, warning only (yugabyte-db#11761), so it would pass while testing
+  nothing."
+  (:require [jepsen.checker :as checker]
+            [jepsen.generator :as gen]
+            [jepsen.history :as h]
+            [yugabyte.generator :as ygen]))
+
+(def ^:private terminal-errors
+  "Enqueue errors meaning the insert certainly did not commit. A whitelist:
+  exception-to-op also labels [:conn-closed ...] :fail, but that is what a backend
+  reports when a kill/stop nemesis takes it down, which a commit that already
+  landed reports too."
+  #{:rollback :conflicting-transaction :try-again :restart-read-required
+    :conn-not-ready})
+
+(defn- error-tag
+  "Leading keyword of an :error, unwrapping exception-to-op's [:batch ...]."
+  [error]
+  (cond (keyword? error)    error
+        (sequential? error) (recur (if (= :batch (first error))
+                                     (second error)
+                                     (first error)))))
+
+(defn enqueues
+  "Infinite stream of :enqueue ops. Payloads are globally unique and increasing,
+  so duplicates and losses are detectable by value alone."
+  []
+  (map (fn [v] {:type :invoke, :f :enqueue, :value v}) (range)))
+
+; One-shot op maps; wrap in `repeat` to emit more than one.
+(def dequeue    {:type :invoke, :f :dequeue, :value nil})
+(def drain      (assoc dequeue :drain? true))
+(def read-table {:type :invoke, :f :read-table, :value nil})
+
+(def drains-per-thread
+  "Hold-free, so a generous quota costs seconds."
+  500)
+
+(def final-reads
+  "A few, so one :info read can't leave the checker without ground truth."
+  5)
+
+(defn main-generator
+  "Half the threads only enqueue, so supply continues even when dequeues block
+  under a nemesis. `stagger` is global in 0.3, hence dividing by threads. A bare
+  op map is a one-shot generator, hence `repeat`."
+  [threads]
+  (->> (gen/reserve (quot threads 2) (enqueues) (repeat dequeue))
+       (gen/stagger (/ 1 threads))))
+
+(defn final-generator
+  "Post-heal drain, then the reads that give the checker its ground truth.
+  Multi-round because a single empty claim proves nothing: SKIP LOCKED also
+  returns nothing for rows that are merely contended."
+  []
+  (gen/phases
+    (gen/each-thread (gen/limit drains-per-thread (repeat drain)))
+    (gen/limit final-reads (repeat read-table))))
+
+(defn- final-read
+  "The last :ok :read-table invoked after every :ok claim completed; an earlier
+  read may predate a straggler claim's commit and misreport it as lost. Only :ok
+  claims count: an :info claim may complete after the reads, and its commit may
+  land after its own completion anyway, so waiting for it protects nothing.
+  gen/phases synchronizes, so this already holds; the filter guards it."
+  [history ops]
+  (let [last-claim (->> ops
+                        (filter #(and (= :dequeue (:f %)) (= :ok (:type %))))
+                        (map :index)
+                        (reduce max -1))]
+    (->> ops
+         (filter #(and (= :ok (:type %)) (= :read-table (:f %))))
+         (filter #(< last-claim (:index (h/invocation history %))))
+         last)))
+
+(def ^:private max-reported
+  "Entries kept per problem key. The table holds every row ever enqueued, so a
+  systemic failure has thousands of payloads to report."
+  32)
+
+(defn- summarize
+  "Bounded rendering of a problem list. Callers sort first, so a sample is the
+  lowest few and is stable across runs."
+  [xs]
+  (let [v (vec xs)]
+    (if (<= (count v) max-reported)
+      v
+      {:count (count v), :sample (subvec v 0 max-reported)})))
+
+(defn- converged?
+  "True if every draining thread ended on an empty claim, so the queue was
+  quiescent and leftover rows are a real loss rather than transient contention. A
+  thread whose final attempt failed for another reason, or was indeterminate,
+  leaves the queue's state unknown there and blocks the conclusion. Grouped by
+  thread, not process: jepsen retires a process after an :info and hands its
+  thread `process + concurrency`, so a retired process alone never looks
+  converged."
+  [test ops]
+  (let [by-thread (->> ops
+                       (filter #(and (:drain? %) (not= :invoke (:type %))))
+                       (group-by #(mod (:process %) (:concurrency test))))]
+    (and (seq by-thread)
+         (every? (fn [os]
+                   (let [l (apply max-key :index os)]
+                     (and (= :fail (:type l)) (= :empty (:error l)))))
+                 (vals by-thread)))))
+
+(defn checker
+  []
+  (reify checker/Checker
+    (check [_ test history _]
+      (let [ops      (h/client-ops history)
+            of       (fn [t f] (filter #(and (= t (:type %)) (= f (:f %))) ops))
+            tried    (set (map :value (of :invoke :enqueue)))
+            failed   (->> (of :fail :enqueue)
+                          (filter (comp terminal-errors error-tag :error))
+                          (map :value)
+                          set)
+            acked    (set (map :value (of :ok :enqueue)))
+            claims   (map (juxt :value :process) (of :ok :dequeue))
+            claimed  (set (map first claims))
+            ; a process is retired after an indeterminate op, so each :info claim
+            ; is one row that process may have claimed unseen
+            unsure   (frequencies (map :process (of :info :dequeue)))
+            read     (final-read history ops)
+            rows     (:value read)
+            row-of   (into {} (map (juxt :payload identity)) rows)
+            drained? (converged? test ops)
+            ; mutual exclusion is visible in the history alone
+            dups     (->> claims (map first) frequencies
+                          (keep (fn [[p n]] (when (< 1 n) p)))
+                          sort)
+            ; the rest needs the final read: without it row-of is empty, which
+            ; would read as "every row lost" rather than "nothing to compare to"
+            table-problems
+            (when read
+              (let [lost-claims (into (sorted-set)
+                                      (for [[p] claims :let [r (row-of p)]
+                                            :when (and r (not (:claimed r)))] p))
+                    unexpected  (into (sorted-set)
+                                      (->> rows (map :payload)
+                                           (filter #(or (not (tried %))
+                                                        (failed %)))))
+                    ; each defect reported once, under its most specific key
+                    explained   (into (set dups) lost-claims)]
+                {:claimer-mismatches
+                 (sort-by :payload
+                          (for [[p c] claims :let [r (row-of p)]
+                                :when (and r (not= c (:claimer r))
+                                           (not (explained p)))]
+                            {:payload p, :claimed-by c, :row-claimer (:claimer r)}))
+                 ; a claim proves the row committed, so it must still be there
+                 :lost-rows       (sort (remove row-of (into acked claimed)))
+                 :lost-claims     lost-claims
+                 :unexpected-rows unexpected
+                 :excess-claims   (->> rows
+                                       (filter :claimed)
+                                       (remove #(claimed (:payload %)))
+                                       (remove #(unexpected (:payload %)))
+                                       (group-by :claimer)
+                                       (mapcat (fn [[proc rs]]
+                                                 (drop (get unsure proc 0)
+                                                       (sort-by :payload rs))))
+                                       (map :payload)
+                                       sort)
+                 :undrained       (when drained?
+                                    (->> rows (remove :claimed) (map :payload)
+                                         (remove unexpected)
+                                         (remove lost-claims)
+                                         sort))}))
+            problems (into {} (comp (remove (comp empty? val))
+                                    (map (fn [[k v]] [k (summarize v)])))
+                           (assoc table-problems :duplicate-claims dups))]
+        (cond-> {:valid?   (cond (seq problems) false
+                                 ; nothing wrong in the history, but most
+                                 ; invariants went unchecked
+                                 (nil? read)    :unknown
+                                 :else          true)
+                 :problems problems
+                 :stats    {:enqueued    (count acked)
+                            :claimed     (count claims)
+                            :rows        (count rows)
+                            :unclaimed   (count (remove :claimed rows))
+                            :final-read? (some? read)
+                            :drain-converged? drained?}}
+          (nil? read)
+          (assoc :error (str "No :ok :read-table was invoked after the last claim "
+                             "committed; only mutual exclusion could be checked.")))))))
+
+(defn workload
+  "Shared by si.queue and rc.queue; only the client's isolation differs."
+  [opts]
+  ; One :op-index counter across both phases: the client stamps it into every
+  ; statement for server-log correlation, and per-phase counters would restart.
+  (let [ctr (atom 0)]
+    {:generator       (ygen/with-op-index ctr (main-generator (:concurrency opts)))
+     :final-generator (ygen/with-op-index ctr (final-generator))
+     :checker         (checker)}))

--- a/yugabyte/src/yugabyte/queue.clj
+++ b/yugabyte/src/yugabyte/queue.clj
@@ -66,10 +66,11 @@
 
 (defn main-generator
   "Half the threads only enqueue, so supply continues even when dequeues block
-  under a nemesis. `stagger` is global in 0.3, hence dividing by threads. A bare
+  under a nemesis; at least one, or a single-threaded run would enqueue nothing
+  and test nothing. `stagger` is global in 0.3, hence dividing by threads. A bare
   op map is a one-shot generator, hence `repeat`."
   [threads]
-  (->> (gen/reserve (quot threads 2) (enqueues) (repeat dequeue))
+  (->> (gen/reserve (max 1 (quot threads 2)) (enqueues) (repeat dequeue))
        (gen/stagger (/ 1 threads))))
 
 (defn final-generator
@@ -141,7 +142,10 @@
                           (map :value)
                           set)
             acked    (set (map :value (of :ok :enqueue)))
-            claims   (map (juxt :value :process) (of :ok :dequeue))
+            ok-deq   (of :ok :dequeue)
+            claims   (map (juxt :value :process) ok-deq)
+            ; rows each claim stepped over; nil on drains, which do not measure
+            skips    (keep :skipped ok-deq)
             claimed  (set (map first claims))
             ; a process is retired after an indeterminate op, so each :info claim
             ; is one row that process may have claimed unseen
@@ -203,6 +207,10 @@
                  :problems problems
                  :stats    {:enqueued    (count acked)
                             :claimed     (count claims)
+                            ; zero here means SKIP LOCKED never had to skip, so the
+                            ; run exercised plain locking and proved little
+                            :rows-skipped        (reduce + 0 skips)
+                            :claims-that-skipped (count (filter pos? skips))
                             :rows        (count rows)
                             :unclaimed   (count (remove :claimed rows))
                             :final-read? (some? read)

--- a/yugabyte/src/yugabyte/queue.clj
+++ b/yugabyte/src/yugabyte/queue.clj
@@ -5,18 +5,21 @@
 
     :enqueue v  -> insert a row with a globally unique, increasing payload.
     :dequeue    -> claim the head of the queue. :ok with the claimed payload, or
-                   :fail :empty when nothing was claimable, which is a legal
-                   outcome and never an anomaly by itself. Ops marked
-                   :drain? true are the final phase's hold-free drain.
-    :read-table -> every row: the checker's ground truth, since a checker sees
-                   only the history, never the database.
+                   :fail :empty when nothing was claimable, which is legal and
+                   never an anomaly by itself. :drain? true marks the final
+                   phase's hold-free drain.
+    :read-table -> every row; the checker's ground truth, since it sees only the
+                   history, never the database.
 
-  Invariants: no payload is claimed twice (mutual exclusion, checked always), and
-  every acked enqueue is still present and eventually claimed (completeness,
-  asserted only once the drain has quiesced, because YugabyteDB also skips rows a
-  committed transaction touched after the reader's read time, so mid-run a row can
-  be briefly invisible to every claimer). Indeterminate claims are budgeted rather
-  than assumed either way.
+  Invariants: no payload is claimed twice, checked always; and every acked
+  enqueue is still present and eventually claimed, checked only once the drain
+  has quiesced, because YugabyteDB also skips rows a committed transaction
+  touched after the reader's read time, so mid-run a row can be briefly invisible
+  to every claimer. Indeterminate claims are budgeted, never assumed either way.
+
+  A run that could not assert an invariant - no final read, or a drain that never
+  quiesced with acked payloads still unclaimed - is :valid? :unknown with an
+  :error, not a green result that checked less than it appears to.
 
   Bespoke rather than jepsen.checker/total-queue: that checker does not fail on
   duplicates, and its drain handling throws on the :info ops a nemesis produces.
@@ -30,10 +33,10 @@
             [yugabyte.generator :as ygen]))
 
 (def ^:private terminal-errors
-  "Enqueue errors meaning the insert certainly did not commit. A whitelist:
-  exception-to-op also labels [:conn-closed ...] :fail, but that is what a backend
-  reports when a kill/stop nemesis takes it down, which a commit that already
-  landed reports too."
+  "Error tags proving the transaction committed nothing. A whitelist, because
+  exception-to-op also labels [:conn-closed ...] :fail, and that is what a
+  backend reports when a nemesis takes it down mid-transaction as well as when a
+  commit already landed."
   #{:rollback :conflicting-transaction :try-again :restart-read-required
     :conn-not-ready})
 
@@ -44,6 +47,13 @@
         (sequential? error) (recur (if (= :batch (first error))
                                      (second error)
                                      (first error)))))
+
+(defn- definitely-failed?
+  "Whether a :fail op's error proves it committed nothing. :empty is our own
+  marker for `no row was claimable`, not an exception-to-op tag."
+  [op]
+  (let [tag (error-tag (:error op))]
+    (or (= :empty tag) (contains? terminal-errors tag))))
 
 (defn enqueues
   "Infinite stream of :enqueue ops. Payloads are globally unique and increasing,
@@ -60,15 +70,19 @@
   "Hold-free, so a generous quota costs seconds."
   500)
 
+(def drain-time-limit
+  "Seconds. core.clj time-limits the main phase only, so without this a cluster
+  that never recovers spends drains-per-thread times the 30s statement timeout on
+  every thread and blows the nightly's per-test budget."
+  120)
+
 (def final-reads
   "A few, so one :info read can't leave the checker without ground truth."
   5)
 
 (defn main-generator
   "Half the threads only enqueue, so supply continues even when dequeues block
-  under a nemesis; at least one, or a single-threaded run would enqueue nothing
-  and test nothing. `stagger` is global in 0.3, hence dividing by threads. A bare
-  op map is a one-shot generator, hence `repeat`."
+  under a nemesis. `stagger` is global in 0.3, hence dividing by threads."
   [threads]
   (->> (gen/reserve (max 1 (quot threads 2)) (enqueues) (repeat dequeue))
        (gen/stagger (/ 1 threads))))
@@ -76,18 +90,19 @@
 (defn final-generator
   "Post-heal drain, then the reads that give the checker its ground truth.
   Multi-round because a single empty claim proves nothing: SKIP LOCKED also
-  returns nothing for rows that are merely contended."
+  returns nothing for rows that are merely contended. The limit wraps only the
+  drain, so an expired drain still leaves the reads to run."
   []
   (gen/phases
-    (gen/each-thread (gen/limit drains-per-thread (repeat drain)))
+    (gen/time-limit drain-time-limit
+                    (gen/each-thread (gen/limit drains-per-thread (repeat drain))))
     (gen/limit final-reads (repeat read-table))))
 
 (defn- final-read
   "The last :ok :read-table invoked after every :ok claim completed; an earlier
   read may predate a straggler claim's commit and misreport it as lost. Only :ok
   claims count: an :info claim may complete after the reads, and its commit may
-  land after its own completion anyway, so waiting for it protects nothing.
-  gen/phases synchronizes, so this already holds; the filter guards it."
+  land after its own completion anyway, so waiting for it protects nothing."
   [history ops]
   (let [last-claim (->> ops
                         (filter #(and (= :dequeue (:f %)) (= :ok (:type %))))
@@ -113,43 +128,48 @@
       {:count (count v), :sample (subvec v 0 max-reported)})))
 
 (defn- converged?
-  "True if every draining thread ended on an empty claim, so the queue was
-  quiescent and leftover rows are a real loss rather than transient contention. A
-  thread whose final attempt failed for another reason, or was indeterminate,
-  leaves the queue's state unknown there and blocks the conclusion. Grouped by
-  thread, not process: jepsen retires a process after an :info and hands its
-  thread `process + concurrency`, so a retired process alone never looks
-  converged."
+  "Whether the drain proved the queue quiescent. Every thread must have run its
+  full quota - a short one means drain-time-limit cut the drain off, and threads
+  that all stop at the same deadline can all see :empty through mutual SKIP
+  LOCKED while rows remain - and every thread's last attempt must have found the
+  queue empty. Grouped by thread, not process: jepsen retires a process after an
+  :info and hands its thread `process + concurrency`."
   [test ops]
   (let [by-thread (->> ops
                        (filter #(and (:drain? %) (not= :invoke (:type %))))
                        (group-by #(mod (:process %) (:concurrency test))))]
-    (and (seq by-thread)
-         (every? (fn [os]
-                   (let [l (apply max-key :index os)]
-                     (and (= :fail (:type l)) (= :empty (:error l)))))
-                 (vals by-thread)))))
+    (boolean
+      (and (seq by-thread)
+           (every? (fn [os]
+                     (and (= drains-per-thread (count os))
+                          (let [l (apply max-key :index os)]
+                            (and (= :fail (:type l)) (= :empty (:error l))))))
+                   (vals by-thread))))))
 
 (defn checker
   []
   (reify checker/Checker
     (check [_ test history _]
       (let [ops      (h/client-ops history)
-            of       (fn [t f] (filter #(and (= t (:type %)) (= f (:f %))) ops))
+            by-t-f   (group-by (juxt :type :f) ops)
+            of       (fn [t f] (by-t-f [t f]))
             tried    (set (map :value (of :invoke :enqueue)))
-            failed   (->> (of :fail :enqueue)
-                          (filter (comp terminal-errors error-tag :error))
-                          (map :value)
-                          set)
+            failed   (->> (of :fail :enqueue) (filter definitely-failed?)
+                          (map :value) set)
             acked    (set (map :value (of :ok :enqueue)))
             ok-deq   (of :ok :dequeue)
             claims   (map (juxt :value :process) ok-deq)
             ; rows each claim stepped over; nil on drains, which do not measure
             skips    (keep :skipped ok-deq)
             claimed  (set (map first claims))
-            ; a process is retired after an indeterminate op, so each :info claim
-            ; is one row that process may have claimed unseen
-            unsure   (frequencies (map :process (of :info :dequeue)))
+            ; Each indeterminate claim is one row that process may have claimed
+            ; unseen. A :fail that is not provably terminal counts too: kill and
+            ; stop nemeses do produce [:conn-closed ...] on a claim whose UPDATE
+            ; already committed.
+            unsure   (frequencies (map :process
+                                       (concat (of :info :dequeue)
+                                               (remove definitely-failed?
+                                                       (of :fail :dequeue)))))
             read     (final-read history ops)
             rows     (:value read)
             row-of   (into {} (map (juxt :payload identity)) rows)
@@ -191,33 +211,49 @@
                                                        (sort-by :payload rs))))
                                        (map :payload)
                                        sort)
+                 ; Only acked enqueues were promised a place in the queue, so only
+                 ; they must have been claimed. A row from an indeterminate
+                 ; enqueue may have committed after the drainers swept past it,
+                 ; and one from a terminally-failed enqueue is already reported
+                 ; under :unexpected-rows.
                  :undrained       (when drained?
                                     (->> rows (remove :claimed) (map :payload)
-                                         (remove unexpected)
+                                         (filter acked)
                                          (remove lost-claims)
                                          sort))}))
             problems (into {} (comp (remove (comp empty? val))
                                     (map (fn [[k v]] [k (summarize v)])))
-                           (assoc table-problems :duplicate-claims dups))]
+                           (assoc table-problems :duplicate-claims dups))
+            ; Why an otherwise-clean history still could not be judged. One
+            ; source of truth for both :valid? and :error.
+            unverified
+            (cond (nil? read)
+                  (str "No :ok :read-table was invoked after the last claim "
+                       "committed; only mutual exclusion could be checked.")
+
+                  ; lost-claims is deliberately not excluded: this only changes
+                  ; :valid? when problems is empty, and a non-empty lost-claims
+                  ; would itself have made problems non-empty.
+                  (and (not drained?)
+                       (seq (filter acked (map :payload (remove :claimed rows)))))
+                  (str "The drain never quiesced while acked payloads were still "
+                       "unclaimed, so completeness could not be asserted. See "
+                       ":drain-converged? and :unclaimed."))]
         (cond-> {:valid?   (cond (seq problems) false
-                                 ; nothing wrong in the history, but most
-                                 ; invariants went unchecked
-                                 (nil? read)    :unknown
+                                 unverified     :unknown
                                  :else          true)
                  :problems problems
-                 :stats    {:enqueued    (count acked)
-                            :claimed     (count claims)
-                            ; zero here means SKIP LOCKED never had to skip, so the
-                            ; run exercised plain locking and proved little
+                 :stats    {:enqueued            (count acked)
+                            :claimed             (count claims)
+                            ; zero means SKIP LOCKED never had to skip, so the run
+                            ; exercised plain locking and proved little
                             :rows-skipped        (reduce + 0 skips)
                             :claims-that-skipped (count (filter pos? skips))
-                            :rows        (count rows)
-                            :unclaimed   (count (remove :claimed rows))
-                            :final-read? (some? read)
-                            :drain-converged? drained?}}
-          (nil? read)
-          (assoc :error (str "No :ok :read-table was invoked after the last claim "
-                             "committed; only mutual exclusion could be checked.")))))))
+                            :rows                (count rows)
+                            :unclaimed           (count (remove :claimed rows))
+                            :final-read?         (some? read)
+                            :drain-converged?    drained?}}
+          unverified (assoc :error unverified))))))
 
 (defn workload
   "Shared by si.queue and rc.queue; only the client's isolation differs."

--- a/yugabyte/src/yugabyte/ysql/queue.clj
+++ b/yugabyte/src/yugabyte/ysql/queue.clj
@@ -16,7 +16,8 @@
 
   Every op runs in a transaction at the client's isolation. Both parts matter: the
   connection default is serializable, where YugabyteDB downgrades SKIP LOCKED to a
-  blocking lock, and a locking read outside a transaction is rejected outright."
+  blocking lock, and the row lock has to outlive the SELECT for concurrent
+  claimers to have anything to skip."
   (:require [clojure.java.jdbc :as j]
             [clojure.string :as str]
             [jepsen.random :as random]
@@ -35,10 +36,11 @@
   50)
 
 (defn- assert-isolation!
-  "Fails setup unless a transaction really runs at the client's isolation. If it
-  silently fell back to the connection default of serializable, YugabyteDB would
-  downgrade SKIP LOCKED to a blocking lock and every assertion would still pass,
-  so the whole test would be vacuous while looking healthy."
+  "Fails setup unless a transaction really runs at the client's isolation: a silent
+  fallback to the connection default of serializable would downgrade SKIP LOCKED
+  to a blocking lock and leave every assertion passing on a vacuous test. Reads
+  the PostgreSQL-level setting, so it does not detect YugabyteDB mapping read
+  committed onto snapshot when yb_enable_read_committed_isolation is off."
   [c isolation]
   (j/with-db-transaction [c c {:isolation isolation}]
     (let [want   (str/replace (name isolation) "-" " ")
@@ -62,8 +64,6 @@
     (assert-isolation! c isolation))
 
   (invoke-op! [this test op c conn-wrapper]
-    ; Explicit isolation on every op, enqueues included, and the locking select is
-    ; only legal inside a transaction at all. See the namespace docstring.
     (j/with-db-transaction [c c {:isolation isolation}]
       (case (:f op)
         :enqueue
@@ -79,19 +79,16 @@
           ; measures how many rows SKIP LOCKED stepped over. Exact at repeatable
           ; read, where the count shares the claim's snapshot; approximate at read
           ; committed, which re-snapshots per statement.
-          (let [skipped (when-not (:drain? op)
-                          (let [s (:skipped (first (c/query op c [(str "select count(*) as skipped from "
-                                                                       table-name " where " unclaimed
-                                                                       " and id < ?")
-                                                                  (:id row)])))]
-                            (Thread/sleep (random/long hold-ms))
-                            s))
-                updated (first (c/execute! op c [(str "update " table-name
-                                                      " set claimed = true, claimer = ? where id = ?")
-                                                 (:process op) (:id row)]))]
-            (when (not= 1 updated)
-              (throw (ex-info "claim updated wrong number of rows"
-                              {:op op, :row row, :updated updated})))
+          (let [measure? (not (:drain? op))
+                skipped  (when measure?
+                           (:skipped (first (c/query op c [(str "select count(*) as skipped from "
+                                                                table-name " where " unclaimed
+                                                                " and id < ?")
+                                                           (:id row)]))))]
+            (when measure? (Thread/sleep (random/long hold-ms)))
+            (c/execute! op c [(str "update " table-name
+                                   " set claimed = true, claimer = ? where id = ?")
+                              (:process op) (:id row)])
             (assoc op :type :ok, :value (:payload row), :skipped skipped))
           (assoc op :type :fail, :error :empty))
 

--- a/yugabyte/src/yugabyte/ysql/queue.clj
+++ b/yugabyte/src/yugabyte/ysql/queue.clj
@@ -1,0 +1,82 @@
+(ns yugabyte.ysql.queue
+  "YSQL client for the SKIP LOCKED work-queue workload (yugabyte.queue).
+
+  Table `queue (id bigint primary key, payload bigint, claimer bigint, claimed
+  boolean)`, plus a partial index over the unclaimed rows, which is the ordered
+  access path a claim scans. `id` and `payload` are both the generated payload;
+  `claimer` records the Jepsen process whose claim committed.
+
+    :enqueue v  -> INSERT (id, payload) = (v, v); claimed takes its default.
+    :dequeue    -> SELECT ... WHERE claimed = false ORDER BY id LIMIT 1 FOR
+                   UPDATE SKIP LOCKED, briefly hold the lock so concurrent
+                   claimers really do skip, then UPDATE claimed and claimer.
+                   :ok with the payload, or :fail :empty for no row. Ops marked
+                   :drain? true skip the hold.
+    :read-table -> payload, claimer and claimed for every row.
+
+  Every op runs in a transaction at the client's isolation. Both parts matter: the
+  connection default is serializable, where YugabyteDB downgrades SKIP LOCKED to a
+  blocking lock, and a locking read outside a transaction is rejected outright."
+  (:require [clojure.java.jdbc :as j]
+            [jepsen.random :as random]
+            [yugabyte.ysql.client :as c]))
+
+(def table-name "queue")
+(def index-name "idx_queue_unclaimed")
+
+(def unclaimed
+  "Shared by the partial index and the claim, so the planner matches them."
+  "claimed = false")
+
+(def hold-ms
+  "Upper bound on a dequeue's lock hold. Without an overlap window concurrent
+  claimers would rarely meet a locked row and SKIP LOCKED would never skip."
+  50)
+
+(defrecord QueueClient [isolation]
+  c/YSQLYbClient
+
+  (setup-cluster! [this test c conn-wrapper]
+    (c/execute! c (j/create-table-ddl table-name
+                                      [[:id :bigint "PRIMARY KEY"]
+                                       [:payload :bigint "NOT NULL"]
+                                       [:claimer :bigint]
+                                       [:claimed :boolean "NOT NULL DEFAULT false"]]
+                                      {:conditional? true}))
+    (c/execute! c (str "CREATE INDEX IF NOT EXISTS " index-name " ON " table-name
+                       " (id ASC) WHERE " unclaimed)))
+
+  (invoke-op! [this test op c conn-wrapper]
+    ; Explicit isolation on every op, enqueues included, and the locking select is
+    ; only legal inside a transaction at all. See the namespace docstring.
+    (j/with-db-transaction [c c {:isolation isolation}]
+      (case (:f op)
+        :enqueue
+        (let [v (:value op)]
+          (c/execute! op c [(str "insert into " table-name " (id, payload) values (?, ?)") v v])
+          (assoc op :type :ok))
+
+        :dequeue
+        (if-let [row (first (c/query op c [(str "select id, payload from " table-name
+                                                " where " unclaimed
+                                                " order by id limit 1 for update skip locked")]))]
+          (do (when-not (:drain? op)
+                (Thread/sleep (random/long hold-ms)))
+              (let [n (first (c/execute! op c [(str "update " table-name
+                                                    " set claimed = true, claimer = ? where id = ?")
+                                               (:process op) (:id row)]))]
+                (when (not= 1 n)
+                  (throw (ex-info "claim updated wrong number of rows"
+                                  {:op op, :row row, :updated n})))
+                (assoc op :type :ok, :value (:payload row))))
+          (assoc op :type :fail, :error :empty))
+
+        :read-table
+        (assoc op :type :ok
+               :value (c/query op c [(str "select payload, claimer, claimed from "
+                                          table-name)])))))
+
+  (teardown-cluster! [this test c conn-wrapper]
+    (c/drop-table c table-name)))
+
+(c/defclient Client QueueClient)

--- a/yugabyte/src/yugabyte/ysql/queue.clj
+++ b/yugabyte/src/yugabyte/ysql/queue.clj
@@ -18,6 +18,7 @@
   connection default is serializable, where YugabyteDB downgrades SKIP LOCKED to a
   blocking lock, and a locking read outside a transaction is rejected outright."
   (:require [clojure.java.jdbc :as j]
+            [clojure.string :as str]
             [jepsen.random :as random]
             [yugabyte.ysql.client :as c]))
 
@@ -33,6 +34,19 @@
   claimers would rarely meet a locked row and SKIP LOCKED would never skip."
   50)
 
+(defn- assert-isolation!
+  "Fails setup unless a transaction really runs at the client's isolation. If it
+  silently fell back to the connection default of serializable, YugabyteDB would
+  downgrade SKIP LOCKED to a blocking lock and every assertion would still pass,
+  so the whole test would be vacuous while looking healthy."
+  [c isolation]
+  (j/with-db-transaction [c c {:isolation isolation}]
+    (let [want   (str/replace (name isolation) "-" " ")
+          actual (:iso (first (c/query c ["select current_setting('transaction_isolation') as iso"])))]
+      (when-not (= want actual)
+        (throw (ex-info "transaction isolation is not what the client asked for"
+                        {:want want, :actual actual}))))))
+
 (defrecord QueueClient [isolation]
   c/YSQLYbClient
 
@@ -44,7 +58,8 @@
                                        [:claimed :boolean "NOT NULL DEFAULT false"]]
                                       {:conditional? true}))
     (c/execute! c (str "CREATE INDEX IF NOT EXISTS " index-name " ON " table-name
-                       " (id ASC) WHERE " unclaimed)))
+                       " (id ASC) WHERE " unclaimed))
+    (assert-isolation! c isolation))
 
   (invoke-op! [this test op c conn-wrapper]
     ; Explicit isolation on every op, enqueues included, and the locking select is
@@ -60,15 +75,24 @@
         (if-let [row (first (c/query op c [(str "select id, payload from " table-name
                                                 " where " unclaimed
                                                 " order by id limit 1 for update skip locked")]))]
-          (do (when-not (:drain? op)
-                (Thread/sleep (random/long hold-ms)))
-              (let [n (first (c/execute! op c [(str "update " table-name
-                                                    " set claimed = true, claimer = ? where id = ?")
-                                               (:process op) (:id row)]))]
-                (when (not= 1 n)
-                  (throw (ex-info "claim updated wrong number of rows"
-                                  {:op op, :row row, :updated n})))
-                (assoc op :type :ok, :value (:payload row))))
+          ; Unclaimed rows below the one we got were not lockable, so counting them
+          ; measures how many rows SKIP LOCKED stepped over. Exact at repeatable
+          ; read, where the count shares the claim's snapshot; approximate at read
+          ; committed, which re-snapshots per statement.
+          (let [skipped (when-not (:drain? op)
+                          (let [s (:skipped (first (c/query op c [(str "select count(*) as skipped from "
+                                                                       table-name " where " unclaimed
+                                                                       " and id < ?")
+                                                                  (:id row)])))]
+                            (Thread/sleep (random/long hold-ms))
+                            s))
+                updated (first (c/execute! op c [(str "update " table-name
+                                                      " set claimed = true, claimer = ? where id = ?")
+                                                 (:process op) (:id row)]))]
+            (when (not= 1 updated)
+              (throw (ex-info "claim updated wrong number of rows"
+                              {:op op, :row row, :updated updated})))
+            (assoc op :type :ok, :value (:payload row), :skipped skipped))
           (assoc op :type :fail, :error :empty))
 
         :read-table


### PR DESCRIPTION
Adds `ysql/si.queue` (repeatable read) and `ysql/rc.queue` (read committed):
purpose-built work-queue workloads for YugabyteDB's documented job-queue
primitive. Enqueuers insert globally unique increasing payloads; claimers take
the head row with `SELECT ... ORDER BY id LIMIT 1 FOR UPDATE SKIP LOCKED`, hold
the lock briefly so concurrent claimers actually have something to skip, then
mark it claimed.

Two invariants:

- **Mutual exclusion** — no payload is ever claimed twice. Checked always; this
  is the headline.
- **Completeness** — every acked enqueue is still present and eventually
  claimed. Checked only once the post-heal drain has quiesced.

New `yugabyte.queue` (generators + checker) and `yugabyte.ysql.queue` (client),
registered in `core.clj` and `run-jepsen.py`. `with-op-index` gains an arity that
shares one counter across both generator phases so server-log correlation stays
unambiguous.

### Design notes

- **No `sz.queue`.** At serializable, YB downgrades SKIP LOCKED to a blocking
  lock with only a WARNING (yugabyte-db#11761) — the variant would pass while
  testing nothing.
- **Bespoke checker, not `jepsen.checker/total-queue`.** Verified against the
  pinned jepsen 0.3.11: `total-queue`'s `:valid?` ignores `:duplicated`, so the
  headline bug would pass silently, and its drain expansion throws on the `:info`
  ops a nemesis produces.
- **Indeterminate ops are budgeted, never assumed.** A claim that committed and
  then lost its connection is not a phantom claim; an enqueue that returned
  `:fail`/`:info` and landed late is not a lost row.
- **Three outcomes.** A run that could not actually assert an invariant — no
  final read, or a drain that never quiesced with acked rows outstanding —
  reports `:valid? :unknown` with an `:error`, rather than a green result that
  checked less than it appears to.

### Testing

12 runs on this branch across 6 fault configs (kill-tserver, kill-master,
pause-tserver, pause-master, partition, kill+pause+partition) x both isolation
levels: all clean, `:unclaimed 0`, drain quiesced in every run. `:rows-skipped`
ranged 2028–8883, confirming SKIP LOCKED genuinely skipped rather than the run
degenerating into plain locking.

**Jenkins run:**
https://jenkins.dev.yugabyte.com/job/jepsen/2018/