### PR TITLE
Add debug logging flags for DDL correctness runs (YQ-4634)

### DIFF
--- a/yugabyte/src/yugabyte/auto.clj
+++ b/yugabyte/src/yugabyte/auto.clj
@@ -758,6 +758,8 @@
                (master-tserver-stress-flags test)
                (master-stress-flags test)
                (master-append-table-flags test)
+               ; Debug logging for DDL correctness issues
+               :--vmodule "pg_client_session=4,async_rpc=2"
                (master-api-opts (:api test) node)]
               (:master-flags test)))))
 
@@ -787,7 +789,11 @@
                (tserver-read-committed-flags test)
                (tserver-serializable-flags test)
                (tserver-append-table-flags test)
-               (tserver-heartbeat-flags test)]
+               (tserver-heartbeat-flags test)
+               ; Debug logging for DDL correctness issues. ysql_pg_conf_csv is
+               ; tserver-only.
+               :--vmodule "pg_client_session=4,async_rpc=2"
+               :--ysql_pg_conf_csv "log_statement=all,yb_debug_log_internal_restarts=true"]
               (:tserver-flags test)))))
 
   (stop-master! [db]


### PR DESCRIPTION
Adds --enable-debug-logging BOOL, defaulting to true, which sets:

```
  vmodule=pg_client_session=4,async_rpc=2   (master and tserver)
  ysql_pg_conf_csv=log_statement=all,yb_debug_log_internal_restarts=true
                                            (tserver only)
```

vmodule is a glog flag and is valid on both daemons. ysql_pg_conf_csv is tserver-only, so it is emitted separately; yb-master aborts at startup on unrecognized flags. It is emitted as a CSV flag, so a value supplied via --tserver-flags is merged with it rather than overwriting it.

The flag takes a value rather than being a bare switch so that callers can pass false explicitly once the default is flipped.

Run on master: https://jenkins.dev.yugabyte.com/view/jepsen/job/jepsen/2034/
Run on 2024.2: https://jenkins.dev.yugabyte.com/view/jepsen/job/jepsen/2035/